### PR TITLE
Bugfixes

### DIFF
--- a/services/alchemy_language/v1.html
+++ b/services/alchemy_language/v1.html
@@ -99,7 +99,9 @@
     <p>For full details on the feature details, please see the <a href="http://www.alchemyapi.com/api">Alchemy API documentation</a></p>
     <p>The content to be analysed should be passed in on <code>msg.payload</code>.</p>
     <p>Valid <code>msg.payload</code> types: URL, HTML or Text Content.</p>
-    <p>If you need to send custom parameters along with each feature, set those parameters as children of the <code>msg.alchemy_options</code> object.</p>
+    <p>If you need to send custom parameters along with each feature, set those parameters as children of the <code>msg.alchemy_options</code> object. eg. to limit the output to 3 values per feature set 
+      <code>msg.alchemy_options = {maxRetrieve: 3};</code>
+    </p>
     <br>
     <p>Results from the Alchemy API service will made available at <code>msg.features</code>. Each feature result will be a separate child property.</p>
 </script>


### PR DESCRIPTION
In the previous conversion from AlchemyAPI SDK to Watson Developer Cloud SDK, the support for msg.alchemy_options had been lost, This has been added. The associated information box for the node, has been updated to show an example of how to pass in the additional parameters.
