### PR TITLE
Bluemix Service credentials for R&R now stored in a configuration node

### DIFF
--- a/services/retrieve_and_rank/v1.html
+++ b/services/retrieve_and_rank/v1.html
@@ -54,7 +54,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -107,9 +107,9 @@
             },
             oneditprepare: function() {
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -129,7 +129,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -194,9 +194,9 @@
                     } 
                 });
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -216,7 +216,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -261,9 +261,9 @@
             },
             oneditprepare: function() {
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -283,7 +283,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -350,9 +350,9 @@
                     } 
                 });
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -372,7 +372,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -448,9 +448,9 @@
                     } 
                 });
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -470,7 +470,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -512,9 +512,9 @@
             },
             oneditprepare: function() {
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -534,7 +534,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -597,9 +597,9 @@
                     } 
                 });
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })
@@ -619,7 +619,7 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row">
+    <div class="form-row servicecreds">
         <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
         <input type="text" id="node-input-servicecreds">
     </div>
@@ -683,9 +683,9 @@
             },
             oneditprepare: function() {
                 $.getJSON('watson-retrieve-and-rank/vcap/').done(function (service) {
-                    $('.credentials').toggle(!service);
+                    $('.servicecreds').toggle(!service);
                 }).fail(function () {
-                    $('.credentials').show();
+                    $('.servicecreds').show();
                 }).always(function () {
                     $('#credentials-check').hide();
                 })

--- a/services/retrieve_and_rank/v1.html
+++ b/services/retrieve_and_rank/v1.html
@@ -13,6 +13,36 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+
+<!-- Service Credentials Configuration Node -->
+<script type="text/x-red" data-template-name="watson-retrieve-rank-credentials">
+    <div class="form-row">
+        <label for="node-config-input-username"><i class="fa fa-user"></i> Username</label>
+        <input type="text" id="node-config-input-username" placeholder="Username">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-password"><i class="fa fa-key"></i> Password</label>
+        <input type="password" id="node-config-input-password" placeholder="Password">
+    </div>
+</script>
+
+<script type="text/javascript">
+(function() {
+    console.log("hello");
+    RED.nodes.registerType('watson-retrieve-rank-credentials',{
+        category: 'config',
+        defaults: { 
+            username:{value: ""},
+            password:{value: ""}
+        },
+        label: function() {
+            return 'Retrieve and Rank Credentials';
+        }
+    });
+})();
+</script>
+
+
 <!-- Create Cluster Node -->
 <script type="text/x-red" data-template-name="watson-retrieve-rank-create-cluster">
     <div id="credentials-check" class="form-row">
@@ -24,13 +54,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row clustername">
         <label for="node-input-clustername"><i class="fa fa-tag"></i> Cluster Name</label>
@@ -64,12 +90,9 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clustername: {value: ""},
                 clustersize: {value: "free"}
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,
@@ -106,13 +129,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row">
         <label for="node-input-mode"><i class="fa fa-question"></i> Mode</label>
@@ -147,6 +166,7 @@
             defaults: {
                 name: {value: ""},
                 mode: {value: "list"},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clusterid: {value: ""}
             },
             credentials: {
@@ -196,13 +216,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row mode clusterid">
         <label for="node-input-clusterid"><i class="fa fa-tag"></i> Cluster ID</label>
@@ -228,12 +244,9 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clusterid: {value: "", required: true},
                 configname: {value: "", required: true}
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,
@@ -270,13 +283,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row clusterid">
         <label for="node-input-clusterid"><i class="fa fa-tag"></i> Cluster ID</label>
@@ -314,14 +323,11 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clusterid: {value: "", required: true},
                 mode: {value: "list"},
                 configname: {value: ""}
                 
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,
@@ -366,13 +372,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row clusterid">
         <label for="node-input-clusterid"><i class="fa fa-tag"></i> Cluster ID</label>
@@ -418,16 +420,13 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clusterid: {value: "", required: true},
                 collectionname: {value: "", required: true},
                 mode: {value: "create"},
                 configname: {value: ""}
                 
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
-            },
+            },          
             color: "rgb(85, 150, 230)",
             inputs: 1,
             outputs: 1,
@@ -471,13 +470,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row rankername">
         <label for="node-input-rankername"><i class="fa fa-tag"></i> Ranker Name</label>
@@ -501,11 +496,8 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 rankername: {value: ""}
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,
@@ -542,13 +534,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row">
         <label for="node-input-mode"><i class="fa fa-question"></i> Mode</label>
@@ -584,12 +572,9 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 mode: {value: "list"},
                 rankerid: {value: ""}
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,
@@ -634,13 +619,9 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
-        <input type="text" id="node-input-username" placeholder="Username">
-    </div>
-    <div class="form-row credentials" style="display: none;">
-        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
-        <input type="password" id="node-input-password" placeholder="Password">
+    <div class="form-row">
+        <label for="node-input-bluemix"><i class="fa fa-user"></i> Service Credentials</label>
+        <input type="text" id="node-input-servicecreds">
     </div>
     <div class="form-row mode clusterid">
         <label for="node-input-clusterid"><i class="fa fa-tag"></i> Cluster ID</label>
@@ -683,14 +664,11 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
                 clusterid: {value: "", required: true},
                 collectionname: {value: "", required: true},
                 searchmode: {value: "search-and-rank"},
                 rankerid: {value: ""}
-            },
-            credentials: {
-              username: {type:"text"},
-              password: {type:"password"}
             },
             color: "rgb(85, 150, 230)",
             inputs: 1,

--- a/services/retrieve_and_rank/v1.html
+++ b/services/retrieve_and_rank/v1.html
@@ -90,7 +90,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clustername: {value: ""},
                 clustersize: {value: "free"}
             },
@@ -166,7 +166,7 @@
             defaults: {
                 name: {value: ""},
                 mode: {value: "list"},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clusterid: {value: ""}
             },
             credentials: {
@@ -244,7 +244,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clusterid: {value: "", required: true},
                 configname: {value: "", required: true}
             },
@@ -323,7 +323,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clusterid: {value: "", required: true},
                 mode: {value: "list"},
                 configname: {value: ""}
@@ -420,7 +420,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clusterid: {value: "", required: true},
                 collectionname: {value: "", required: true},
                 mode: {value: "create"},
@@ -496,7 +496,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 rankername: {value: ""}
             },
             color: "rgb(85, 150, 230)",
@@ -572,7 +572,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 mode: {value: "list"},
                 rankerid: {value: ""}
             },
@@ -664,7 +664,7 @@
             category: 'IBM Watson',
             defaults: {
                 name: {value: ""},
-                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials'},
+                servicecreds: {value: "", type: 'watson-retrieve-rank-credentials', required: false},
                 clusterid: {value: "", required: true},
                 collectionname: {value: "", required: true},
                 searchmode: {value: "search-and-rank"},

--- a/services/retrieve_and_rank/v1.js
+++ b/services/retrieve_and_rank/v1.js
@@ -36,6 +36,11 @@ module.exports = function (RED) {
     res.json(service ? {bound_service: true} : null);
   });
 
+  function serviceCredentialsConfigurationNode(config) {
+    RED.nodes.createNode(this,config);
+    this.username = config.username;
+    this.password = config.password;
+  }
  
   function createRankerNode(config) {
     RED.nodes.createNode(this, config);
@@ -419,12 +424,9 @@ module.exports = function (RED) {
     });
   }
 
-  RED.nodes.registerType('watson-retrieve-rank-create-cluster', createClusterNode, {
-    credentials: {
-      username: {type:"text"},
-      password: {type:"password"}
-    }
-  });
+  RED.nodes.registerType("watson-retrieve-rank-credentials", serviceCredentialsConfigurationNode);
+  RED.nodes.registerType('watson-retrieve-rank-create-cluster', createClusterNode);
+
   RED.nodes.registerType('watson-retrieve-rank-cluster-settings', clusterSettingsNode, {
     credentials: {
       username: {type:"text"},
@@ -477,8 +479,10 @@ module.exports = function (RED) {
     }
 
     //Check credentials
-    username = username || node.credentials.username;
-    password = password || node.credentials.password;
+    this.credentials = RED.nodes.getNode(config.servicecreds);
+    console.log(config);
+    username = username || this.credentials.username;
+    password = password || this.credentials.password;
 
     if (!username || !password) {
       message = 'Missing Concept Insights service credentials';


### PR DESCRIPTION
Fix for Issue #67 - Tested locally and on Bluemix and the desired behaviour is achieved. This PR allows the user to enter the service credentials once in a configuration node and then access that configuration across all R+R nodes. The nodes still pick up the bound service credentials when running in Bluemix
