### PR TITLE
New Tone Analzer node for V3 GA API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Node-RED Watson Nodes for IBM Bluemix
 - The transcription returned for the Speech to Text node now returns full (untruncated) transcription. The
 alternatives are returned in msg.fullresult. The dialog now loads available models dynamically. This will
 allow new speech models to be identified without requiring a further code change. 
+- The Retrieve and Rank node nows stores credentials in a configuration node, allowing the credentials to be 
+shared acrosss a flow with multiple Retrieve and Rank nodes.
+- New Tone Analyzer V3 node to support the V3 GA API. 
 
 ### New in version 0.4.1
 - AlchemyAPI Image Analysis and Language nodes migrated from old Alchemy SDK to current 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "watson-text-to-speech-v1": "services/text_to_speech/v1.js",
       "watson-tradeoff-analytics-v1": "services/tradeoff_analytics/v1.js",
       "watson-tone-analyzer-v3-beta": "services/tone_analyzer/v3-beta.js",
+      "watson-tone-analyzer-v3": "services/tone_analyzer/v3.js",
       "watson-visual-recognition-v1": "services/visual_recognition/v1.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "temp": "^0.8.3",
     "qs": "6.x",
 	  "image-type": "^2.0.2",
-    "watson-developer-cloud": "^1.2.4"
+    "watson-developer-cloud": "^1.9.2"
   },
   "repository": {
     "type": "git",

--- a/services/tone_analyzer/v3-beta.html
+++ b/services/tone_analyzer/v3-beta.html
@@ -52,6 +52,8 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-tone-analyzer">
+    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for anyone that has old credentials. It will no longer work with new credentials.</p>
+    <br/>
     <p>The Tone Analyzer service uses linguistic analysis to detect emotional tones, social propensities, and writing styles in written communication.</p>
     <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
     <p>The service response will be returned on <b>msg.response</b>.</p>

--- a/services/tone_analyzer/v3-beta.html
+++ b/services/tone_analyzer/v3-beta.html
@@ -57,6 +57,7 @@
     <p>The service response will be returned on <b>msg.response</b>.</p>
     <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and whether to include sentence-level analysis.</p>
     <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>
+    <p><b>NB:</b> This is the old beta version and it is only being retained for backward compatibility for anyone that has old credentials. It will no longer work with new credentials.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -64,7 +64,7 @@
     <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
     <p>The service response will be returned on <b>msg.response</b>.</p>
     <p>The tone and sentances can be programmaticaly set in <code>msg.tones</code>
-    and <code>msg.tones</code></p>
+    and <code>msg.sentences</code></p>
     <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and 
       whether to include sentence-level analysis.</p>
     <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -84,9 +84,9 @@
             inputs: 1,
             outputs: 1,
             icon: "tone_analyzer.png",
-            paletteLabel: "tone analyzer",
+            paletteLabel: "tone analyzer v3",
             label: function() {
-                return this.name || "tone analyzer";
+                return this.name || "tone analyzer v3";
             },
             labelStyle: function() {
                 return this.name ? "node_label_italic" : "";

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -58,7 +58,7 @@
  
 </script>
 
-<script type="text/x-red" data-help-name="watson-tone-analyzer">
+<script type="text/x-red" data-help-name="watson-tone-analyzer-v3">
     <p>The Tone Analyzer service uses linguistic analysis to detect emotional tones, social propensities, and writing styles in written communication.</p>
     <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
     <p>The service response will be returned on <b>msg.response</b>.</p>

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -1,0 +1,107 @@
+<!--
+  Copyright 2013,2015 IBM Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-template-name="watson-tone-analyzer-v3">
+    <div id="credentials-check" class="form-row">
+        <div class="form-tips">
+            <i class="fa fa-question-circle"></i><b> Please wait: </b> Checking for bound service credentials...
+        </div>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row credentials" style="display: none;">
+        <label for="node-input-username"><i class="fa fa-user"></i> Username</label>
+        <input type="text" id="node-input-username" placeholder="Username">
+    </div>
+    <div class="form-row credentials" style="display: none;">
+        <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
+        <input type="password" id="node-input-password" placeholder="Password">
+    </div>
+    <div class="form-row">
+        <label for="node-input-tones"><i class="fa fa-comments-o"></i> Tones</label>
+        <select type="text" id="node-input-tones" style="display: inline-block; width: 70%;" >
+            <option value="all">All</option>
+            <option value="emotion">Emotion</option>
+            <option value="language">Language</option>
+            <option value="social">Social</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-sentences"><i class="fa fa-language"></i> Sentences</label>
+        <select type="text" id="node-input-sentences" style="display: inline-block; width: 70%;" >
+            <option value="true">True</option>
+            <option value="false">False</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-contentType"><i class="fa fa-comments-o"></i> Content type</label>
+        <select type="text" id="node-input-contentType" style="display: inline-block; width: 70%;" >
+            <option value="false">Text</option>
+            <option value="true">HTML</option>
+        </select>
+    </div>
+ 
+</script>
+
+<script type="text/x-red" data-help-name="watson-tone-analyzer">
+    <p>The Tone Analyzer service uses linguistic analysis to detect emotional tones, social propensities, and writing styles in written communication.</p>
+    <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
+    <p>The service response will be returned on <b>msg.response</b>.</p>
+    <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and whether to include sentence-level analysis.</p>
+    <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>
+</script>
+
+<script type="text/javascript">
+    (function() {
+        RED.nodes.registerType('watson-tone-analyzer-v3', {
+            category: 'IBM Watson',
+            defaults: {
+                name: {value: ""},
+                tones: {value: "all"},
+                sentences: {value: "true"},
+                contentType: {value: "false"}
+            },
+            credentials: {
+              username: {type:"text"},
+              password: {type:"password"}
+            },
+            color: "rgb(84,149,230)",
+            inputs: 1,
+            outputs: 1,
+            icon: "tone_analyzer.png",
+            paletteLabel: "tone analyzer",
+            label: function() {
+                return this.name || "tone analyzer";
+            },
+            labelStyle: function() {
+                return this.name ? "node_label_italic" : "";
+            },
+            oneditprepare: function() {
+                $.getJSON('watson-tone-analyzer/vcap/')
+                  .done(function (service) {
+                    $('.credentials').toggle(!service);
+                  })
+                  .fail(function () {
+                    $('.credentials').show();
+                  }).always(function () {
+                    $('#credentials-check').hide();
+                  })
+            }
+        });
+    })();
+</script>

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -59,10 +59,14 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-tone-analyzer-v3">
-    <p>The Tone Analyzer service uses linguistic analysis to detect emotional tones, social propensities, and writing styles in written communication.</p>
+    <p>The Tone Analyzer service uses linguistic analysis to detect emotional tones, social propensities, 
+       and writing styles in written communication.</p>
     <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
     <p>The service response will be returned on <b>msg.response</b>.</p>
-    <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and whether to include sentence-level analysis.</p>
+    <p>The tone and sentances can be programmaticaly set in <code>msg.tones</code>
+    and <code>msg.tones</code></p>
+    <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and 
+      whether to include sentence-level analysis.</p>
     <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>
 </script>
 

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -102,23 +102,26 @@ module.exports = function (RED) {
     }
   };
 
+  // Function to parse and determine tone setting
+  // 'all' is the setting which needs be be blanked
+  // if not the service will throw an error
+  var parseToneOption = function (msg, config) {
+    var tones = msg.tones || config.tones;
+
+    return (tones === 'all' ? '' : tones);
+  }
+
   // function to parse through the options in preparation
   // for the sevice call.
   var parseOptions = function (msg, config) {
-    var tones = msg.tones || config.tones;
-    // var sentences = msg.sentences || config.sentences;
-    // var contentType = msg.contentType || config.contentType;
 
     var options = {
       'text': msg.payload,
       'sentences': msg.sentences || config.sentences,   
-      'isHTML': msg.contentType || config.contentType,   
-      'tones' : (tones === 'all' ? '' : tones)
+      'isHTML': msg.contentType || config.contentType    
     };
 
-    //if (tones !== 'all') {
-    // options.tones = tones;
-    //}
+    options.tones = parseToneOption(msg, config);
 
     return options;
   }

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -91,9 +91,7 @@ module.exports = function (RED) {
 
     if (!taSettings) {
       message = 'Missing Tone Analyzer service credentials';
-    }
-
-    if (!message && !msg.payload) {
+    } else if (!msg.payload) {
       message = 'Missing property: msg.payload';
     } 
 

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -107,7 +107,7 @@ module.exports = function (RED) {
   var parseOptions = function (msg, config) {
     var tones = msg.tones || config.tones;
     var sentences = msg.sentences || config.sentences;
-    var contentType = msg.contentType || config.contentType
+    var contentType = msg.contentType || config.contentType;
 
     var options = {
       'text': msg.payload,

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -71,13 +71,8 @@ module.exports = function (RED) {
     var taSettings = {};
 
     // Credentials are needed for each of the modes.
-    // Deliberate break to check what codacy says about complexity
-    //username = sUsername || node.credentials.username;
-    //password = sPassword || node.credentials.password;      
-
-    username = node.credentials.username;
-    password = node.credentials.password;      
-
+    username = sUsername || node.credentials.username;
+    password = sPassword || node.credentials.password;      
 
     if (!username || !password) {
       message = 'Missing Tone Analyzer service credentials';

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -46,17 +46,19 @@ module.exports = function (RED) {
   // whether it is JSON or a Buffer
   var checkPayload = function(payload) {
     var message = null;
+    var isBuffer = false;
 
     var hasJSONmethod = (typeof payload.toJSON === 'function') ;
-      if (hasJSONmethod === true) {
-        if (payload.toJSON().type === 'Buffer') {
-          isBuffer = true;
-        }      
+
+    if (hasJSONmethod === true) {
+      if (payload.toJSON().type === 'Buffer') {
+        isBuffer = true;
       }      
-      // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
-      if (typeof payload !== 'string' &&  isBuffer !== true) {
-        message = 'The payload must be either a string or a Buffer';
-      }
+    }      
+    // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
+    if (typeof payload !== 'string' &&  isBuffer !== true) {
+      message = 'The payload must be either a string or a Buffer';
+    }
 
     return message;
   }
@@ -66,7 +68,6 @@ module.exports = function (RED) {
   // payload and options have been proviced in the correct format.
   var checkConfiguration = function(msg, config, node, cb) {
     var message = null;      
-    var isBuffer = false;
     var taSettings = {};
 
     // Credentials are needed for each of the modes.

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -34,14 +34,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
-    this.on('input', function (msg, config, node) {
-      callToneAnalyzer(msg);
-    });
-
-  }
-
-  var callToneAnalyzer = function(msg, config, node) {
-    var message = '';
+    this.on('input', function (msg) {
+      var message = '';
 
       if (!msg.payload) {
         message = 'Missing property: msg.payload';
@@ -108,6 +102,7 @@ module.exports = function (RED) {
         node.status({fill:'red', shape:'dot', text:message}); 
         node.error(message, msg);         
       }
+    });
   }
   RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
     credentials: {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -85,20 +85,6 @@ module.exports = function (RED) {
   };
 
 
-  // function to parse through the options in preparation
-  // for the sevice call.
-  var parseOptions = function (msg, config) {
-    var options = {
-      'text': msg.payload,
-      'sentences': msg.sentences || config.sentences,   
-      'isHTML': msg.contentType || config.contentType    
-    };
-
-    options.tones = toneutils.parseToneOption(msg, config);
-    return options;
-  }
-
-
   // function when the node recieves input inside a flow. 
   // Configuration is first checked before the service is invoked.
   var processOnInput = function(msg, config, node) {
@@ -115,7 +101,7 @@ module.exports = function (RED) {
           'version_date': '2016-05-19'
         });
 
-        var options = parseOptions(msg, config);
+        var options = toneutils.parseOptions(msg, config);
     
         node.status({fill:'blue', shape:'dot', text:'requesting'});
         tone_analyzer.tone(options, function (err, response) {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -114,7 +114,6 @@ module.exports = function (RED) {
   // function to parse through the options in preparation
   // for the sevice call.
   var parseOptions = function (msg, config) {
-
     var options = {
       'text': msg.payload,
       'sentences': msg.sentences || config.sentences,   
@@ -122,7 +121,6 @@ module.exports = function (RED) {
     };
 
     options.tones = parseToneOption(msg, config);
-
     return options;
   }
 

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2013,2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+module.exports = function (RED) {
+  var cfenv = require('cfenv');
+  
+  var services = cfenv.getAppEnv().services,
+    service;
+
+  var username, password;
+
+  var service = cfenv.getAppEnv().getServiceCreds(/tone analyzer/i)
+
+  if (service) {
+    username = service.username;
+    password = service.password;
+  }
+
+  RED.httpAdmin.get('/watson-tone-analyzer/vcap', function (req, res) {
+    res.json(service ? {bound_service: true} : null);
+  });
+
+  function Node (config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+
+    this.on('input', function (msg) {
+      if (!msg.payload) {
+        var message = 'Missing property: msg.payload';
+        node.error(message, msg);
+        return;
+      }
+
+      username = username || this.credentials.username;
+      password = password || this.credentials.password;
+
+      if (!username || !password) {
+        var message = 'Missing Tone Analyzer service credentials';
+        node.error(message, msg);
+        return;
+      }
+
+      var tones = msg.tones || config.tones;
+      var sentences = msg.sentences || config.sentences;
+      var contentType = msg.contentType || config.contentType
+
+      var watson = require('watson-developer-cloud');
+
+      var tone_analyzer = watson.tone_analyzer({
+        username: username,
+        password: password,
+        version: 'v3',
+        version_date: '2016-05-19'
+      });
+
+      var hasJSONmethod = (typeof msg.payload.toJSON === 'function') ;
+      var isBuffer = false;
+      if (hasJSONmethod==true)
+      {
+        if (msg.payload.toJSON().type == 'Buffer')
+            isBuffer=true;
+      }
+
+      // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
+      if (typeof msg.payload == 'string' ||  isBuffer == true )
+      {
+        var options = {
+          text: msg.payload,
+          sentences: config.sentences,
+          isHTML: contentType
+        };
+
+        if (tones !== 'all') {
+          options.tones =   tones;
+        }
+
+        console.log(options);
+
+        node.status({fill:'blue', shape:'dot', text:'requesting'});
+        tone_analyzer.tone(options, function (err, response) {
+          node.status({})
+          if (err) {
+            node.error(err, msg);
+          } else {
+            msg.response = response;
+          }
+
+          node.send(msg);
+        });
+      }
+      else {
+        var message = 'The payload must be either a string or a Buffer';
+        node.status({fill:'red', shape:'dot', text:message}); 
+        node.error(message, msg);         
+      }
+    });
+  }
+  RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
+    credentials: {
+      username: {type:'text'},
+      password: {type:'password'}
+    }
+  });
+};

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -82,7 +82,7 @@ module.exports = function (RED) {
 
 
   // Function that checks the configuration to make sure that credentials,
-  // payload and options have been proviced in the correct format.
+  // payload and options have been provided in the correct format.
   var checkConfiguration = function(msg, node, cb) {
     var message = null;      
     var taSettings = null;
@@ -93,11 +93,10 @@ module.exports = function (RED) {
       message = 'Missing Tone Analyzer service credentials';
     } else if (!msg.payload) {
       message = 'Missing property: msg.payload';
-    } 
-
-    if (!message) {
-      message = checkPayload(msg.payload);
-    }
+      if (!message) {
+        message = checkPayload(msg.payload);
+      }
+    }     
 
     if (cb) {
       cb(message, taSettings);
@@ -117,8 +116,14 @@ module.exports = function (RED) {
       'isHTML': contentType     
     };
 
-    if (tones !== 'all') {
-      options.tones = tones;
+    // if (tones !== 'all') {
+    //  options.tones = tones;
+    // }
+
+    switch (tones) {
+      case 'all':
+        options.tones = tones
+        break;
     }
 
     return options;

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -17,6 +17,7 @@
 module.exports = function (RED) {
   var watson = require('watson-developer-cloud');  
   var cfenv = require('cfenv');
+  var toneutils = require('../../utilities/tone-utils');
 
   // Require the Cloud Foundry Module to pull credentials from bound service 
   // If they are found then they are stored in sUsername and sPassword, as the 
@@ -37,31 +38,13 @@ module.exports = function (RED) {
     sPassword = service.password;
   }
 
+  //toneutils.ping();
+
   // Node RED Admin - fetch and set vcap services
   RED.httpAdmin.get('/watson-tone-analyzer/vcap', function (req, res) {
     res.json(service ? {bound_service: true} : null);
   });
 
-  // Function that checks the payload and determines
-  // whether it is JSON or a Buffer
-  var checkPayload = function(payload) {
-    var message = null;
-    var isBuffer = false;
-
-    var hasJSONmethod = (typeof payload.toJSON === 'function') ;
-
-    if (hasJSONmethod === true) {
-      if (payload.toJSON().type === 'Buffer') {
-        isBuffer = true;
-      }      
-    }      
-    // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
-    if (typeof payload !== 'string' &&  isBuffer !== true) {
-      message = 'The payload must be either a string or a Buffer';
-    }
-
-    return message;
-  };
 
   // Check that the credentials have been provided
   // Credentials are needed for each the service.
@@ -92,7 +75,7 @@ module.exports = function (RED) {
     if (!taSettings) {
       message = 'Missing Tone Analyzer service credentials';
     } else if (msg.payload) {
-      message = checkPayload(msg.payload);
+      message = toneutils.checkPayload(msg.payload);
     } else  {
       message = 'Missing property: msg.payload';
     }

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -56,10 +56,6 @@ module.exports = function (RED) {
       var sentences = msg.sentences || config.sentences;
       var contentType = msg.contentType || config.contentType
 
-      callToneAnalyzer(username, password, msg, tones, sentences, contentType);
-    });
-
-    var callToneAnalyzer = function(username, password, msg, tones, sentences, contentType) {
       var watson = require('watson-developer-cloud');
 
       var tone_analyzer = watson.tone_analyzer({
@@ -106,9 +102,8 @@ module.exports = function (RED) {
         node.status({fill:'red', shape:'dot', text:message}); 
         node.error(message, msg);         
       }
-    }
+    });
   }
-
   RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
     credentials: {
       username: {type:'text'},

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -48,6 +48,12 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
+    // added in this flag as codacy was complaing about the 
+    // cyclomatic complexity. Essentially the number of exit points. With
+    // this flag we can reduce that do two exits. One if there is an
+    // error detected and the second for normal processing
+    var errorDetected = false;
+
     // Invoked whenb the node has received an input as part of a flow.
     this.on('input', function (msg) {
       var message = '';
@@ -58,12 +64,15 @@ module.exports = function (RED) {
 
       if (!username || !password) {
         message = 'Missing Tone Analyzer service credentials';
-        node.error(message, msg);
-        return;
+        errorDetected = true;
       }
 
       if (!msg.payload) {
         message = 'Missing property: msg.payload';
+        errorDetected = true;
+      }
+
+      if (errorDetected) {
         node.error(message, msg);
         return;
       }
@@ -72,7 +81,8 @@ module.exports = function (RED) {
       var sentences = msg.sentences || config.sentences;
       var contentType = msg.contentType || config.contentType
 
-
+      // Taking out the username and password, as because of EcmaScript 6 any value: key pair with the 
+      // same name eg username and username are implied and don't need to be specified. 
       var tone_analyzer = watson.tone_analyzer({
         username: username,
         password: password,
@@ -119,7 +129,7 @@ module.exports = function (RED) {
       }
     });
   }
-  
+
 
   RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
     credentials: {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -56,9 +56,13 @@ module.exports = function (RED) {
 
       if (!username || !password) {
         message = 'Missing Tone Analyzer service credentials';
-      } else if (!msg.payload) {
+      }
+
+      if (!message && !msg.payload) {
         message = 'Missing property: msg.payload';
-      } else {
+      } 
+
+      if (!message) {
         var hasJSONmethod = (typeof msg.payload.toJSON === 'function') ;
 
         if (hasJSONmethod === true) {
@@ -66,30 +70,24 @@ module.exports = function (RED) {
             isBuffer = true;
           }      
         }      
+
         // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
         if (typeof msg.payload !== 'string' &&  isBuffer !== true) {
           message = 'The payload must be either a string or a Buffer';
         }
       }
 
-      if (message) {
-        cb(message, null);
-        return;        
+      var taSettings = {};
+
+      if (!message) {
+        taSettings.username = username;
+        taSettings.password = password;
+        taSettings.tones = msg.tones || config.tones;
+        taSettings.sentences = msg.sentences || config.sentences;
+        taSettings.contentType = msg.contentType || config.contentType
       }
 
-      var tones = msg.tones || config.tones;
-      var sentences = msg.sentences || config.sentences;
-      var contentType = msg.contentType || config.contentType
-
-      var taSettings = {
-        'username' : username, 
-        'password' : password,
-        'tones' : tones,
-        'sentences' : sentences,
-        'contentType' : contentType
-      };
-
-      cb(null, taSettings);
+      cb(message, taSettings);
     }
   };
 

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -89,15 +89,32 @@ module.exports = function (RED) {
     if (!message) {
       taSettings.username = username;
       taSettings.password = password;
-      //taSettings.tones = msg.tones || config.tones;
-      //taSettings.sentences = msg.sentences || config.sentences;
-      //taSettings.contentType = msg.contentType || config.contentType
     }
 
     if (cb) {
       cb(message, taSettings);
     }
   };
+
+  // function to parse through the options in preparation
+  // for the sevice call.
+  var parseOptions = function (msg, config) {
+    var tones = msg.tones || config.tones;
+    var sentences = msg.sentences || config.sentences;
+    var contentType = msg.contentType || config.contentType
+
+    var options = {
+      'text': msg.payload,
+      'sentences': sentences,   
+      'isHTML': contentType     
+    };
+
+    if (tones !== 'all') {
+      options.tones = tones;
+    }
+
+    return options;
+  }
 
 
   // function when the node recieves input inside a flow. 
@@ -116,19 +133,7 @@ module.exports = function (RED) {
           'version_date': '2016-05-19'
         });
 
-        var tones = msg.tones || config.tones;
-        var sentences = msg.sentences || config.sentences;
-        var contentType = msg.contentType || config.contentType
-
-        var options = {
-          'text': msg.payload,
-          'sentences': sentences,   // settings.sentences,
-          'isHTML': contentType     // settings.contentType
-        };
-
-        if (tones !== 'all') {
-          options.tones = tones;
-        }
+        var options = parseOptions(msg, config);
     
         node.status({fill:'blue', shape:'dot', text:'requesting'});
         tone_analyzer.tone(options, function (err, response) {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -87,8 +87,6 @@ module.exports = function (RED) {
           options.tones =   tones;
         }
 
-        console.log(options);
-
         node.status({fill:'blue', shape:'dot', text:'requesting'});
         tone_analyzer.tone(options, function (err, response) {
           node.status({})

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -66,7 +66,7 @@ module.exports = function (RED) {
 
   // Function that checks the configuration to make sure that credentials,
   // payload and options have been proviced in the correct format.
-  var checkConfiguration = function(msg, config, node, cb) {
+  var checkConfiguration = function(msg, node, cb) {
     var message = null;      
     var taSettings = {};
 
@@ -89,9 +89,9 @@ module.exports = function (RED) {
     if (!message) {
       taSettings.username = username;
       taSettings.password = password;
-      taSettings.tones = msg.tones || config.tones;
-      taSettings.sentences = msg.sentences || config.sentences;
-      taSettings.contentType = msg.contentType || config.contentType
+      //taSettings.tones = msg.tones || config.tones;
+      //taSettings.sentences = msg.sentences || config.sentences;
+      //taSettings.contentType = msg.contentType || config.contentType
     }
 
     if (cb) {
@@ -103,7 +103,7 @@ module.exports = function (RED) {
   // function when the node recieves input inside a flow. 
   // Configuration is first checked before the service is invoked.
   var processOnInput = function(msg, config, node) {
-    checkConfiguration (msg, config, node, function(err, settings){
+    checkConfiguration (msg, node, function(err, settings){
       if (err) {
         node.status({fill:'red', shape:'dot', text:err}); 
         node.error(err, msg);
@@ -116,14 +116,18 @@ module.exports = function (RED) {
           'version_date': '2016-05-19'
         });
 
+        var tones = msg.tones || config.tones;
+        var sentences = msg.sentences || config.sentences;
+        var contentType = msg.contentType || config.contentType
+
         var options = {
           'text': msg.payload,
-          'sentences': settings.sentences,
-          'isHTML': settings.contentType
+          'sentences': sentences,   // settings.sentences,
+          'isHTML': contentType     // settings.contentType
         };
 
-        if (settings.tones !== 'all') {
-          options.tones =   settings.tones;
+        if (tones !== 'all') {
+          options.tones = tones;
         }
     
         node.status({fill:'blue', shape:'dot', text:'requesting'});

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -56,6 +56,10 @@ module.exports = function (RED) {
       var sentences = msg.sentences || config.sentences;
       var contentType = msg.contentType || config.contentType
 
+      callToneAnalyzer(username, password, msg, tones, sentences, contentType);
+    });
+
+    var callToneAnalyzer = function(username, password, msg, tones, sentences, contentType) {
       var watson = require('watson-developer-cloud');
 
       var tone_analyzer = watson.tone_analyzer({
@@ -75,7 +79,7 @@ module.exports = function (RED) {
       }
 
       // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
-      if (typeof msg.payload === 'string' ||  isBuffer === true ) {
+      if (typeof msg.payload === 'string' ||  isBuffer === true) {
         var options = {
           text: msg.payload,
           sentences: sentences,
@@ -97,14 +101,14 @@ module.exports = function (RED) {
 
           node.send(msg);
         });
-      }
-      else {
+      } else {
         message = 'The payload must be either a string or a Buffer';
         node.status({fill:'red', shape:'dot', text:message}); 
         node.error(message, msg);         
       }
-    });
+    }
   }
+
   RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
     credentials: {
       username: {type:'text'},

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -112,12 +112,13 @@ module.exports = function (RED) {
     var options = {
       'text': msg.payload,
       'sentences': msg.sentences || config.sentences,   
-      'isHTML': msg.contentType || config.contentType     
+      'isHTML': msg.contentType || config.contentType,   
+      'tones' : (tones === 'all' ? '' : tones)
     };
 
-    if (tones !== 'all') {
-      options.tones = tones;
-    }
+    //if (tones !== 'all') {
+    // options.tones = tones;
+    //}
 
     return options;
   }

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -71,8 +71,13 @@ module.exports = function (RED) {
     var taSettings = {};
 
     // Credentials are needed for each of the modes.
-    username = sUsername || node.credentials.username;
-    password = sPassword || node.credentials.password;      
+    // Deliberate break to check what codacy says about complexity
+    //username = sUsername || node.credentials.username;
+    //password = sPassword || node.credentials.password;      
+
+    username = node.credentials.username;
+    password = node.credentials.password;      
+
 
     if (!username || !password) {
       message = 'Missing Tone Analyzer service credentials';

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -38,7 +38,7 @@ module.exports = function (RED) {
       var message = '';
 
       if (!msg.payload) {
-        var message = 'Missing property: msg.payload';
+        message = 'Missing property: msg.payload';
         node.error(message, msg);
         return;
       }
@@ -70,13 +70,12 @@ module.exports = function (RED) {
 
       if (hasJSONmethod === true) {
         if (msg.payload.toJSON().type === 'Buffer') {
-          isBuffer=true;
+          isBuffer = true;
         }      
       }
 
       // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
-      if (typeof msg.payload === 'string' ||  isBuffer === true )
-      {
+      if (typeof msg.payload === 'string' ||  isBuffer === true ) {
         var options = {
           text: msg.payload,
           sentences: sentences,

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -16,9 +16,6 @@
 
 module.exports = function (RED) {
   var cfenv = require('cfenv');
-  
-  var services = cfenv.getAppEnv().services,
-    service;
 
   var username, password;
 
@@ -38,6 +35,8 @@ module.exports = function (RED) {
     var node = this;
 
     this.on('input', function (msg) {
+      var message = '';
+
       if (!msg.payload) {
         var message = 'Missing property: msg.payload';
         node.error(message, msg);
@@ -48,7 +47,7 @@ module.exports = function (RED) {
       password = password || this.credentials.password;
 
       if (!username || !password) {
-        var message = 'Missing Tone Analyzer service credentials';
+        message = 'Missing Tone Analyzer service credentials';
         node.error(message, msg);
         return;
       }
@@ -68,18 +67,19 @@ module.exports = function (RED) {
 
       var hasJSONmethod = (typeof msg.payload.toJSON === 'function') ;
       var isBuffer = false;
-      if (hasJSONmethod==true)
-      {
-        if (msg.payload.toJSON().type == 'Buffer')
-            isBuffer=true;
+
+      if (hasJSONmethod === true) {
+        if (msg.payload.toJSON().type === 'Buffer') {
+          isBuffer=true;
+        }      
       }
 
       // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
-      if (typeof msg.payload == 'string' ||  isBuffer == true )
+      if (typeof msg.payload === 'string' ||  isBuffer === true )
       {
         var options = {
           text: msg.payload,
-          sentences: config.sentences,
+          sentences: sentences,
           isHTML: contentType
         };
 
@@ -100,7 +100,7 @@ module.exports = function (RED) {
         });
       }
       else {
-        var message = 'The payload must be either a string or a Buffer';
+        message = 'The payload must be either a string or a Buffer';
         node.status({fill:'red', shape:'dot', text:message}); 
         node.error(message, msg);         
       }

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -34,8 +34,14 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
-    this.on('input', function (msg) {
-      var message = '';
+    this.on('input', function (msg, config, node) {
+      callToneAnalyzer(msg);
+    });
+
+  }
+
+  var callToneAnalyzer = function(msg, config, node) {
+    var message = '';
 
       if (!msg.payload) {
         message = 'Missing property: msg.payload';
@@ -102,7 +108,6 @@ module.exports = function (RED) {
         node.status({fill:'red', shape:'dot', text:message}); 
         node.error(message, msg);         
       }
-    });
   }
   RED.nodes.registerType('watson-tone-analyzer-v3', Node, {
     credentials: {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -61,6 +61,23 @@ module.exports = function (RED) {
     }
 
     return message;
+  };
+
+  // Check that the credentials have been provided
+  // Credentials are needed for each the service.
+  var checkCreds = function(credentials) {
+    var taSettings = null;
+
+    username = sUsername || credentials.username;
+    password = sPassword || credentials.password;      
+
+    if (username && password) {
+      taSettings = {};
+      taSettings.username = username;
+      taSettings.password = password;
+    }
+
+    return taSettings;
   }
 
 
@@ -68,13 +85,11 @@ module.exports = function (RED) {
   // payload and options have been proviced in the correct format.
   var checkConfiguration = function(msg, node, cb) {
     var message = null;      
-    var taSettings = {};
+    var taSettings = null;
 
-    // Credentials are needed for each of the modes.
-    username = sUsername || node.credentials.username;
-    password = sPassword || node.credentials.password;      
+    taSettings = checkCreds(node.credentials);
 
-    if (!username || !password) {
+    if (!taSettings) {
       message = 'Missing Tone Analyzer service credentials';
     }
 
@@ -84,11 +99,6 @@ module.exports = function (RED) {
 
     if (!message) {
       message = checkPayload(msg.payload);
-    }
-
-    if (!message) {
-      taSettings.username = username;
-      taSettings.password = password;
     }
 
     if (cb) {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -106,13 +106,13 @@ module.exports = function (RED) {
   // for the sevice call.
   var parseOptions = function (msg, config) {
     var tones = msg.tones || config.tones;
-    var sentences = msg.sentences || config.sentences;
-    var contentType = msg.contentType || config.contentType;
+    // var sentences = msg.sentences || config.sentences;
+    // var contentType = msg.contentType || config.contentType;
 
     var options = {
       'text': msg.payload,
-      'sentences': sentences,   
-      'isHTML': contentType     
+      'sentences': msg.sentences || config.sentences,   
+      'isHTML': msg.contentType || config.contentType     
     };
 
     if (tones !== 'all') {

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -38,7 +38,6 @@ module.exports = function (RED) {
     sPassword = service.password;
   }
 
-  //toneutils.ping();
 
   // Node RED Admin - fetch and set vcap services
   RED.httpAdmin.get('/watson-tone-analyzer/vcap', function (req, res) {
@@ -85,14 +84,6 @@ module.exports = function (RED) {
     }
   };
 
-  // Function to parse and determine tone setting
-  // 'all' is the setting which needs be be blanked
-  // if not the service will throw an error
-  var parseToneOption = function (msg, config) {
-    var tones = msg.tones || config.tones;
-
-    return (tones === 'all' ? '' : tones);
-  }
 
   // function to parse through the options in preparation
   // for the sevice call.
@@ -103,7 +94,7 @@ module.exports = function (RED) {
       'isHTML': msg.contentType || config.contentType    
     };
 
-    options.tones = parseToneOption(msg, config);
+    options.tones = toneutils.parseToneOption(msg, config);
     return options;
   }
 

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -82,7 +82,7 @@ module.exports = function (RED) {
 
 
   // Function that checks the configuration to make sure that credentials,
-  // payload and options have been provided in the correct format.
+  // payload and options have been provied in the correct format.
   var checkConfiguration = function(msg, node, cb) {
     var message = null;      
     var taSettings = null;
@@ -91,12 +91,11 @@ module.exports = function (RED) {
 
     if (!taSettings) {
       message = 'Missing Tone Analyzer service credentials';
-    } else if (!msg.payload) {
+    } else if (msg.payload) {
+      message = checkPayload(msg.payload);
+    } else  {
       message = 'Missing property: msg.payload';
-      if (!message) {
-        message = checkPayload(msg.payload);
-      }
-    }     
+    }
 
     if (cb) {
       cb(message, taSettings);
@@ -116,14 +115,8 @@ module.exports = function (RED) {
       'isHTML': contentType     
     };
 
-    // if (tones !== 'all') {
-    //  options.tones = tones;
-    // }
-
-    switch (tones) {
-      case 'all':
-        options.tones = tones
-        break;
+    if (tones !== 'all') {
+      options.tones = tones;
     }
 
     return options;

--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -43,10 +43,8 @@ module.exports = function (RED) {
   });
 
 
-  // This is the Tone Analyzer Node. 
-  function Node (config) {
-    RED.nodes.createNode(this, config);
-    var node = this;
+  var processOnInput = function(msg, config, node) {
+      var message = '';
 
     // added in this flag as codacy was complaing about the 
     // cyclomatic complexity. Essentially the number of exit points. With
@@ -55,13 +53,9 @@ module.exports = function (RED) {
     var errorDetected = false;
     var isBuffer = false;
 
-    // Invoked whenb the node has received an input as part of a flow.
-    this.on('input', function (msg) {
-      var message = '';
-
       // Credentials are needed for each of the modes.
-      username = sUsername || this.credentials.username;
-      password = sPassword || this.credentials.password;      
+      username = sUsername || node.credentials.username;
+      password = sPassword || node.credentials.password;      
 
       if (!username || !password) {
         message = 'Missing Tone Analyzer service credentials';
@@ -134,7 +128,17 @@ module.exports = function (RED) {
 
         node.send(msg);
       });
+  };
 
+
+  // This is the Tone Analyzer Node. 
+  function Node (config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+
+    // Invoked whenb the node has received an input as part of a flow.
+    this.on('input', function (msg) {
+      processOnInput(msg, config, node);
     });
   }
 

--- a/utilities/tone-utils.js
+++ b/utilities/tone-utils.js
@@ -51,6 +51,19 @@ ToneUtils.prototype = {
     var tones = msg.tones || config.tones;
 
     return (tones === 'all' ? '' : tones);  	
+  },
+
+  // function to parse through the options in preparation
+  // for the sevice call.
+  parseOptions: function(msg, config) {
+    var options = {
+      'text': msg.payload,
+      'sentences': msg.sentences || config.sentences,   
+      'isHTML': msg.contentType || config.contentType    
+    };
+
+    options.tones = toneutils.parseToneOption(msg, config);
+    return options;
   }
 
 

--- a/utilities/tone-utils.js
+++ b/utilities/tone-utils.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+function ToneUtils () {
+}
+
+
+ToneUtils.prototype = {
+  check: function () {
+    return '"IBM Watson Node-RED Utilities for Tone Analyser';
+  },
+
+  // Function that checks the payload and determines
+  // whether it is JSON or a Buffer
+  checkPayload: function(payload) {
+    var message = null;
+    var isBuffer = false;
+
+    var hasJSONmethod = (typeof payload.toJSON === 'function') ;
+
+    if (hasJSONmethod === true) {
+      if (payload.toJSON().type === 'Buffer') {
+        isBuffer = true;
+      }      
+    }      
+    // Payload (text to be analysed) must be a string (content is either raw string or Buffer)
+    if (typeof payload !== 'string' &&  isBuffer !== true) {
+      message = 'The payload must be either a string or a Buffer';
+    }
+
+    return message;
+  }
+
+
+};
+
+var toneutils = new ToneUtils();
+
+module.exports = toneutils;

--- a/utilities/tone-utils.js
+++ b/utilities/tone-utils.js
@@ -62,7 +62,7 @@ ToneUtils.prototype = {
       'isHTML': msg.contentType || config.contentType    
     };
 
-    options.tones = toneutils.parseToneOption(msg, config);
+    options.tones = this.parseToneOption(msg, config);
     return options;
   }
 

--- a/utilities/tone-utils.js
+++ b/utilities/tone-utils.js
@@ -42,6 +42,15 @@ ToneUtils.prototype = {
     }
 
     return message;
+  },
+
+  // Function to parse and determine tone setting
+  // 'all' is the setting which needs be be blanked
+  // if not the service will throw an error
+  parseToneOption: function(msg, config) {
+    var tones = msg.tones || config.tones;
+
+    return (tones === 'all' ? '' : tones);  	
   }
 
 


### PR DESCRIPTION
A new Tone Analyzer node developed to support the newly GA version of the API. The old V3 beta node has been retained for backward compatibility so that any existing flows with valid (old credentials) are not broken.
The package pre-reqs have been updated to the the level of the watson-developer-cloud SDK that provides support for the GA Tone Analyser API (1.9.2)
The functions have been simplified to pass through codacy checks.
