### PR TITLE
New Deprecated Category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 Node-RED Watson Nodes for IBM Bluemix
 =====================================
 
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/e157cf8407f2442396789dc78075340a)](https://www.codacy.com/app/rezgui-y/node-red-node-watson)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/4f98536040924add9da4ca1deecb72b4)](https://www.codacy.com/app/BetaWorks-NodeRED-Watson/node-red-node-watson?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=watson-developer-cloud/node-red-node-watson&amp;utm_campaign=Badge_Grade)
 
 ### New in version 0.4.4
-- Bugfixes to Speech to Text
+- New palette category for deprecated Nodes, that are being retained for backward compatibity.
+- Bugfixes to Speech to Text.
 
 ### New in version 0.4.3
 - New Visual Recognition V3 node to support the V3 GA API. This incorporates the features that were previously

--- a/services/alchemy_vision/v1.html
+++ b/services/alchemy_vision/v1.html
@@ -40,6 +40,9 @@
 </script>
 
 <script type="text/x-red" data-help-name="alchemy-image-analysis">
+    <p><b>NB:</b> The service behind this node has been merged with Visual Recognition. 
+    This node uses the old beta API and it is only being retained for backward compatibility for anyone that has an old AlchemyAPI key. It will no longer work with new AlchemyAPI keys.</p>
+    <br/>
     <p>Using the Image Analysis node, you can use the Alchemy APIs to analyse images for face detection, content tags and links.</p>
     <p>The following features are available for analysis:</p>
     <ul>
@@ -61,7 +64,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('alchemy-image-analysis', {
-            category: 'IBM Watson',
+            category: "Watson Deprecated",
             defaults: {
               name: {value: ""},
               apikey: {value: ""},

--- a/services/tone_analyzer/v3-beta.html
+++ b/services/tone_analyzer/v3-beta.html
@@ -65,7 +65,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('watson-tone-analyzer', {
-            category: 'IBM Watson',
+            category: 'Watson Deprecated',
             defaults: {
                 name: {value: ""},
                 tones: {value: "all"},

--- a/services/visual_recognition/v1.html
+++ b/services/visual_recognition/v1.html
@@ -35,7 +35,9 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-visual-recognition">
-    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for anyone that has an olde AlchemyAPI key. It will no longer work with new AlchemyAPI keys.</p>
+    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for 
+        anyone that has an Visual Recognition credentials. 
+        It will no longer work with new Visual Recognition keys.</p>
     <br/>
     <p>The Visual Recognition service analyses images to understand their contents.</p>
     <p>The image to be analysed should be passed in on <code>msg.payload</code>.</p>
@@ -51,7 +53,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('watson-visual-recognition', {
-            category: 'IBM Watson',
+            category: 'Watson Deprecated',
             defaults: {
                 name: {value: ""},
             },
@@ -117,7 +119,7 @@
 	}
 
 	RED.nodes.registerType('watson-visual-util',{
-		category: 'IBM_Watson',
+		category: 'Watson Deprecated',
 		color: '#FFFF80',
 		defaults: {
 			name: {value:""},
@@ -227,7 +229,7 @@
 	});
 
 	RED.nodes.registerType('watson-visual-training',{
-		category: 'IBM_Watson',
+		category: 'Watson Deprecated',
 		color: '#FFFF80',
 		defaults: {
 			name: {value:""},
@@ -356,7 +358,9 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-visual-util">
-    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for anyone that has an olde AlchemyAPI key. It will no longer work with new AlchemyAPI keys.</p>
+    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for 
+        anyone that has an Visual Recognition credentials. 
+        It will no longer work with new Visual Recognition keys.</p>
     <br/>
     <p>A node for managing the classifiers in the Visual Recognition service in Watson</p>
 	<p>More information about this service can be found in the 
@@ -392,6 +396,10 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-visual-training">
+    <p><b>NB:</b> This node uses the old beta API and it is only being retained for backward compatibility for 
+        anyone that has an Visual Recognition credentials. 
+        It will no longer work with new Visual Recognition keys.</p>
+    <br/>
 	<p>A node for training the Visual Recognition service in Watson</p>
 	<p>This service requires that two sets of images are provided for the training. These sets of files should be 
 	zipped and provided to the node either as binary streams or as URL's. The positive and negative set of images 


### PR DESCRIPTION
To avoid confusion a new Deprecated category has been created for the deprecated nodes. Currently this is Alchemy Vision, Tone Analyzer Beta, and Visual Recognition Beta. 
