### PR TITLE
Deprecate Concept Insights and Relationship Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Node-RED Watson Nodes for IBM Bluemix
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
 ### New in version 0.4.10
+- Moved Relationship Extraction and Concept Insights nodes to the deprecated list.
 
 ### New in version 0.4.9
 - Added in German and Japanese support to Natural Language Classifier node

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   ],
   "node-red": {
     "nodes": {
-      "watson-concept-insights-v2": "services/concept_insights/v2.js",
       "watson-conversation-v1":"services/conversation/v1.js",
       "watson-conversation-v1-experimental":"services/conversation/v1-exp.js",
       "watson-document-conversion-v1": "services/document_conversion/v1.js",
+      "watson-concept-insights-v2": "services/concept_insights/v2.js",
       "watson-dialog-v1": "services/dialog/v1.js",
       "alchemy_language-v1": "services/alchemy_language/v1.js",
       "watson-language-identification-v1": "/services/language_identification/v1.js",

--- a/services/concept_insights/v2.html
+++ b/services/concept_insights/v2.html
@@ -39,7 +39,7 @@
         <label for="node-config-input-publiccorpus"><i class="fa fa-globe"></i> Public Corpus</label>
         <select type="text" id="node-config-input-publiccorpus">
             <option value="TEDTalks">TED Talks</option>
-            
+
         </select>
     </div>
 </script>
@@ -48,7 +48,7 @@
 (function() {
     RED.nodes.registerType('watson-concept-insights-corpus',{
         category: 'config',
-        defaults: { 
+        defaults: {
             cname:{value: ""},
             access:{value: "private"},
             corpusmode: {value: "user"},
@@ -111,6 +111,12 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-concept-insights-upload-document">
+    <p><b>NB:</b> The Watson Concept Insights service has been deprecated in favour of Concepts in
+    AlchemyLanguage. Once the service
+    has been switched off this node will no longer work. The node will be removed from the palette in a
+    future release. </p>
+    <br/>
+
     <p>The IBM Watson™ Concept Insights service enables you to identify conceptual associations in the content that you provide. Input content is auto-tagged against a concept graph, which is a formal representation of the relationships between concepts that are present in the data. The concept graph used by the Concept Insights service is based on content that has been ingested from the English language Wikipedia.</p>
     <p>The upload document node can be used to upload a document to a specified corpus for indexing and analysis. The file to be uploaded should be passed into the node on <code>msg.payload</code>.</p>
     <p>Supported <code>msg.payload</code> types:</b>.</p>
@@ -124,7 +130,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('watson-concept-insights-upload-document', {
-            category: 'IBM Watson',
+            category: 'Watson Deprecated',
             defaults: {
                 name: {value: ""},
                 corpus: {value: "", type: 'watson-concept-insights-corpus'},
@@ -220,6 +226,11 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-concept-insights-search">
+     <p><b>NB:</b> The Watson Concept Insights service has been deprecated in favour of Concepts in
+     AlchemyLanguage. Once the service
+     has been switched off this node will no longer work. The node will be removed from the palette in a
+     future release. </p>
+    <br/>
     <p>The IBM Watson™ Concept Insights service enables you to identify conceptual associations in the content that you provide. Input content is auto-tagged against a concept graph, which is a formal representation of the relationships between concepts that are present in the data. The concept graph used by the Concept Insights service is based on content that has been ingested from the English language Wikipedia.</p>
     <p>The search node can be used to search a corpus or individual documents within a corpus. A corpus configuration can be specified within the node configuration panel. The node has two modes, <b>corpus</b> mode and <b>document</b> mode. In <b>corpus</b> mode, the following queries can be executed:</p>
     <ul>
@@ -242,7 +253,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('watson-concept-insights-search', {
-            category: 'IBM Watson',
+            category: 'Watson Deprecated',
             defaults: {
                 name: {value: ""},
                 corpus: {value: "", type: 'watson-concept-insights-corpus'},
@@ -271,19 +282,19 @@
                 $('#node-input-mode').change(function () {
                     var mode = $('#node-input-mode').val();
                     $('.form-row.mode.' + mode +':not(.query)').show();
-                    $('.form-row.mode:not(.' + mode + ')').hide();  
+                    $('.form-row.mode:not(.' + mode + ')').hide();
                 });
 
                 $('#node-input-corpusapicall').change(function () {
-                    
+
                     $('#node-input-corpusapicall').change(function () {
                         var mode = $('#node-input-corpusapicall').val();
                         if (mode == 'documentlabel') {
-                          $('.form-row.mode.corpus.query').show();  
+                          $('.form-row.mode.corpus.query').show();
                         } else {
                           $('.form-row.mode.corpus.query').hide();
-                        }  
-                    }); 
+                        }
+                    });
                 });
 
                 $.getJSON('watson-concept-insights/vcap/').done(function (service) {
@@ -321,6 +332,11 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-concept-insights-search-concepts">
+    <p><b>NB:</b> The Watson Concept Insights service has been deprecated in favour of Concepts in
+    AlchemyLanguage. Once the service
+    has been switched off this node will no longer work. The node will be removed from the palette in a
+    future release. </p>
+    <br/>
     <p>The IBM Watson™ Concept Insights service enables you to identify conceptual associations in the content that you provide. Input content is auto-tagged against a concept graph, which is a formal representation of the relationships between concepts that are present in the data. The concept graph used by the Concept Insights service is based on content that has been ingested from the English language Wikipedia.</p>
     <p>The search concepts node can be used to search the English language Wikipedia content graph for concepts closely matching a given search term. The search term should be passed into the node on <code>msg.payload</code>.</p>
     <p>Supported <code>msg.payload</code> types:</b>.</p>
@@ -334,7 +350,7 @@
 <script type="text/javascript">
 (function() {
     RED.nodes.registerType('watson-concept-insights-search-concepts',{
-        category: 'IBM Watson',
+        category: 'Watson Deprecated',
         credentials: {
           username: {type:"text"},
           password: {type:"password"}
@@ -386,6 +402,11 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-concept-insights-related-concepts">
+    <p><b>NB:</b> The Watson Concept Insights service has been deprecated in favour of Concepts in
+    AlchemyLanguage. Once the service
+    has been switched off this node will no longer work. The node will be removed from the palette in a
+    future release. </p>
+    <br/>
     <p>The IBM Watson™ Concept Insights service enables you to identify conceptual associations in the content that you provide. Input content is auto-tagged against a concept graph, which is a formal representation of the relationships between concepts that are present in the data. The concept graph used by the Concept Insights service is based on content that has been ingested from the English language Wikipedia.</p>
     <p>The related concepts node returns related concepts for a given set of source concepts. The source concepts are passed in as an <b>array</b> on <code>msg.concepts</code> and the related concepts are returned on <code>msg.payload</code>.</p>
     <p>For more information about the Concept Insights service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/concept-insights.html">documentation</a>.</p>
@@ -394,7 +415,7 @@
 <script type="text/javascript">
 (function() {
     RED.nodes.registerType('watson-concept-insights-related-concepts',{
-        category: 'IBM Watson',
+        category: 'Watson Deprecated',
         credentials: {
           username: {type:"text"},
           password: {type:"password"}

--- a/services/conversation/v1-exp.html
+++ b/services/conversation/v1-exp.html
@@ -41,8 +41,14 @@
 
 
 <script type="text/x-red" data-help-name="watson-conversation-v1-experimental">
-	<p>(Deprecated on 2016-08-01) With the IBM Watson™ Conversation service you can create cognitive agents – virtual agents that combine machine learning, natural language understanding, and integrated dialog scripting tools to provide outstanding customer engagements.</p>
-
+	<p>This node is for the experimental version of the Watson Conversation service which
+  was made generally available 2016-08-01. Please switch to the Node that supports the
+  generally available version of the service.</p>
+  <br/>
+  <p>
+  With the IBM Watson™ Conversation service you can create cognitive agents –
+  virtual agents that combine machine learning, natural language understanding, and
+  integrated dialog scripting tools to provide outstanding customer engagements.</p>
 
     <p><b>Usage</b></p>
     <p>This node should be provided in input : </p>

--- a/services/relationship_extraction/v1.html
+++ b/services/relationship_extraction/v1.html
@@ -44,6 +44,11 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-relationship-extraction">
+    <p><b>NB:</b> The Watson Relationship Extraction service hase been deprecated. Once the service
+    has been switched off this node will no longer work. The node will be removed from the palette in a
+    future release. </p>
+    <br/>
+
     <p>The Relationship Extraction service intelligently finds relationships between sentence components (nouns, verbs,
     subjects, objects, etc.). From unstructured text, it can extract entities (such as people, locations, organizations,
     events), and the relationships between these entities (such as person employed-by organization, person resides-in location).</p>
@@ -60,7 +65,7 @@
 <script type="text/javascript">
     (function() {
         RED.nodes.registerType('watson-relationship-extraction', {
-            category: 'IBM Watson',
+            category: 'Watson Deprecated',
             defaults: {
                 name: {value: ""},
                 dataset: {value: "ie-en-news"}


### PR DESCRIPTION
Move the Concept Insights and Relationship Extraction nodes to the deprecated category.
