### PR TITLE
Urgent fix for Watson Language Translation node

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Node-RED Watson Nodes for IBM Bluemix
 
 ### New in version 0.4.12
 - Emergency fix for node.js version compatibility problem, in payload-utils
+- Emergency fix for Watson Language Translation node detected proactively. (not reported)
 
 ### New in version 0.4.11
 - Corrected word count for Japanese text in Personality Insights nodes.

--- a/services/language_translation/v2.js
+++ b/services/language_translation/v2.js
@@ -33,7 +33,7 @@ module.exports = function (RED) {
   // Not ever used, and codeacy complains about it.
   // var services = cfenv.getAppEnv().services;
 
-  var username, password, sUsername, sPassword;
+  var username = null, password = null, sUsername = null, sPassword = null;
 
   var service = cfenv.getAppEnv().getServiceCreds(/language translation/i)
 
@@ -93,6 +93,14 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     var node = this;
 
+    // The dynamic nature of this node has caused problems with the password field. it is
+    // hidden but not a credential. If it is treated as a credential, it gets lost when there
+    // is a request to refresh the model list.
+    // Credentials are needed for each of the modes.
+
+    username = sUsername || this.credentials.username;
+    password = sPassword || this.credentials.password || config.password;
+
     // this does nothing, but am keeping it with a commented out signature, as
     // it might come in handy in the future.
     this.on('close', function() {
@@ -105,15 +113,6 @@ module.exports = function (RED) {
     this.on('input', function (msg) {
 
       var message = '';
-
-      // The dynamic nature of this node has caused problems with the password field. it is
-      // hidden but not a credential. If it is treated as a credential, it gets lost when there
-      // is a request to refresh the model list.
-      //
-      // Credentials are needed for each of the modes.
-
-      username = sUsername || this.credentials.username;
-      password = sPassword || this.credentials.password || config.password;
 
       if (!username || !password) {
         message = 'Missing Language Translation service credentials';

--- a/services/language_translation/v2.js
+++ b/services/language_translation/v2.js
@@ -250,6 +250,7 @@ module.exports = function (RED) {
                 text: 'call to translation service failed'
               });
               node.error(err, msg);
+              console.log('getStatus ('+trainid+') Error : ',err, model);
             } else {
               msg.payload = model.status;
               msg.translation = model;

--- a/services/language_translation/v2.js
+++ b/services/language_translation/v2.js
@@ -250,7 +250,6 @@ module.exports = function (RED) {
                 text: 'call to translation service failed'
               });
               node.error(err, msg);
-              console.log('getStatus ('+trainid+') Error : ',err, model);
             } else {
               msg.payload = model.status;
               msg.translation = model;

--- a/services/language_translation/v2.js
+++ b/services/language_translation/v2.js
@@ -220,6 +220,7 @@ module.exports = function (RED) {
                   msg.payload = 'Model ' + model.name + ' successfully sent for training with id: ' + model.model_id;
                   msg.trained_model_id = model.model_id;
                   node.send(msg);
+                  node.status({});
                 }
               }
             );


### PR DESCRIPTION
- Fixed the credentials issue when Watson Language Translation instance is bound to Node-RED.
- Clean node status after a successful train request
- added a console.log in case of error on the getStatus
