### PR TITLE
Updating urls to Language Translator service

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ A collection of nodes to interact with the IBM Watson services in [IBM Bluemix](
       content present in the image.
 - Language Identification
     - Detects the language used in text
-- Language Translator
+- Language Translation
     - Translates text from one language to another    
 - Natural Language Classifier
     - Uses machine learning algorithms to return the top matching predefined classes for short text inputs.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ A collection of nodes to interact with the IBM Watson services in [IBM Bluemix](
       content present in the image.
 - Language Identification
     - Detects the language used in text
-- Language Translation
+- Language Translator
     - Translates text from one language to another    
 - Natural Language Classifier
     - Uses machine learning algorithms to return the top matching predefined classes for short text inputs.

--- a/services/language_translator/v2.html
+++ b/services/language_translator/v2.html
@@ -181,7 +181,7 @@
     <p><b>Local</b>  -  Local parametres if the node is used by its own (default value).</p>
     <p><b>Global</b> -  Global parametres if the node is used with the 'language translator util' and 'dropdown' node.
     Global parameters are set when <b>local in unchecked</b>.</p>
-    <p>For more information about the Language Translator service, read the <a href="https://www.ibm.com/watson/developercloud/doc/language-translator">documentation</a>.</p>
+    <p>For more information about the Language Translator service, read the <a href="https://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translator_identify/v2.html
+++ b/services/language_translator_identify/v2.html
@@ -48,7 +48,7 @@
     with the associated confidence score</li>
     </ul>
     <p>For more information about the Language Identification service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/language-translator/">documentation</a>.</p>
+    read the service <a href="https://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translator_util/v2.html
+++ b/services/language_translator_util/v2.html
@@ -49,7 +49,7 @@
     <p>Message Domains (e.g.: Conversational)<code>msg.domain</code>.</p>
     <p>Message Source Language (e.g.: English)<code>msg.source</code>.</p>
     <p>Message Target Language (e.g.: French)<code>msg.target</code>.</p>
-    <p>For more information about the Language Translator service, read the <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-translator/index.html">documentation</a>.</p>
+    <p>For more information about the Language Translator service, read the <a href="http://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
 </script>
 
 

--- a/services/language_translator_util/v2.html
+++ b/services/language_translator_util/v2.html
@@ -49,7 +49,7 @@
     <p>Message Domains (e.g.: Conversational)<code>msg.domain</code>.</p>
     <p>Message Source Language (e.g.: English)<code>msg.source</code>.</p>
     <p>Message Target Language (e.g.: French)<code>msg.target</code>.</p>
-    <p>For more information about the Language Translator service, read the <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-translation.html">documentation</a>.</p>
+    <p>For more information about the Language Translator service, read the <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-translator/index.html">documentation</a>.</p>
 </script>
 
 


### PR DESCRIPTION
The service docs changed from shtml format to markdown-based html format, so updating the urls to go directly to the new home page for the documentation.