### PR TITLE
Fix to Visual Recognition Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Node-RED Watson Nodes for IBM Bluemix
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.5.2
+- Visual Recognition was overwriting msg.payload with 'look at msg.results'. Fixed
+so that msg.payload is left as is.
+
+
 ### New in version 0.5.1
 - Implement methods to manage for Intent and Example Input for Intent, in
 Conversation workspace Manager node.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "alchemy-api": "^1.3.0",

--- a/services/visual_recognition/v3.js
+++ b/services/visual_recognition/v3.js
@@ -120,7 +120,6 @@ module.exports = function (RED) {
       msg.result = {};
       msg.result['error_id'] = body.images[0].error.error_id;
       msg.result['error'] = body.images[0].error.description;
-      msg.payload = 'see msg.result.error';
       node.send(msg);
     } else {
       if (feature === 'deleteClassifier') {
@@ -128,7 +127,6 @@ module.exports = function (RED) {
       } else {
         msg.result = body;
       }
-      msg.payload = 'see msg.result'; // to remove any Buffer that could remains
       node.send(msg);
       node.status({});
     }
@@ -257,10 +255,8 @@ module.exports = function (RED) {
         });
         async.parallel(asyncTasks, function(error, deletedList){
           if (deletedList.length === nbTodelete) {
-            msg.payload = 'see msg.result.error';
             msg.result = 'All custom classifiers have been deleted.';
           } else {
-            msg.payload = 'see msg.result.error';
             msg.result = 'Some Classifiers could have not been deleted;' +
             'See log for errors.';
           }


### PR DESCRIPTION
Visual Recognition node was overwriting msg.payload with a message stating that the service response could be found in msg.result. The node has been fixed to leave msg.payload as is.