### PR TITLE
Mode Setting for Visual Recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Node-RED Watson Nodes for IBM Bluemix
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.5.10
+- Allowed detect_mode for Visual Recognition node to be set in msg.params
+
 ### New in version 0.5.9
 - Text to Speech speech on msg.payload option.
 - Speech to Text transcription on msg.payload option

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "alchemy-api": "^1.3.0",

--- a/services/visual_recognition/v3.html
+++ b/services/visual_recognition/v3.html
@@ -90,6 +90,7 @@
     <p>This feature should be provided in input : </p>
     <ul>
     <li><code>msg.payload</code> : the URL or the Node.js Buffer of an image. Redirects are followed, so you can use shortened URLs. (Required)</li>
+    <li><code>msg.params["detect_mode"]</code> : A setting of "classify", "faces" or "text" indicating the visual recognition feature required. "Default" is "classify" (string) (Optional)</li>
     <li><code>msg.params["classifier_ids"]</code> : A comma-separated list of the classifier IDs used to classify the images. "Default" is the classifier_id of the built-in classifier. (string) (Optional)</li>
     <li><code>msg.params["owners"]</code> : A comma-separated list with the value(s) "IBM" and/or "me" to specify which classifiers to run. (string) (Optional)</li>
     <li><code>msg.params["threshold"]</code> : A floating value (in string format) that specifies the minimum score a class must have to be displayed in the response (Optional)</li>
@@ -176,7 +177,7 @@
               // which is confusing our users
               var currfeature = $('#node-input-image-feature').val();
               if (!currfeature) {
-                $("#node-input-image-feature option[value='classifyImage']").prop('selected', true);  
+                $("#node-input-image-feature option[value='classifyImage']").prop('selected', true);
               }
 
               // update list of ruleset for the selected service when the service changes

--- a/services/visual_recognition/v3.js
+++ b/services/visual_recognition/v3.js
@@ -72,6 +72,36 @@ module.exports = function(RED) {
     }
   }
 
+// "classify", "faces" or "text"
+//             <option value="detectFaces">Detect Faces</option>
+//            <option value="recognizeText">Recognize Text</option>
+// <option selected="selected" value="classifyImage">Classify an image</option>
+
+
+  function verifyFeatureMode(node, msg, config) {
+    const theOptions = {
+      'classify' : 'classifyImage',
+      'faces' : 'detectFaces',
+      'text' : 'recognizeText'
+    };
+
+    var f = config['image-feature'];
+
+    if (msg.params && msg.params.detect_mode)
+    {
+      if (msg.params.detect_mode in theOptions) {
+        f = theOptions[msg.params.detect_mode];
+      } else {
+        node.error('Invalid parameter setting for detect_mode, using configuration value');
+      }
+    }
+    if (!f) {
+      node.error('No configuration value for detect mode found, defaulting to classify');
+      f = theOptions['classify'];
+    }
+    return Promise.resolve(f);
+  }
+
   function verifyInputs(feature, msg) {
     switch (feature) {
     case 'classifyImage':
@@ -477,7 +507,8 @@ module.exports = function(RED) {
   function WatsonVisualRecognitionV3Node(config) {
     var node = this,
       b = false,
-      feature = config['image-feature'];
+      feature = '';
+
     RED.nodes.createNode(this, config);
     node.config = config;
 
@@ -488,6 +519,10 @@ module.exports = function(RED) {
 
       verifyPayload(msg)
         .then(function() {
+          return verifyFeatureMode(node, msg, config);
+        })
+        .then(function(f) {
+          feature = f;
           return checkForStream(msg);
         })
         .then(function() {

--- a/services/visual_recognition/v3.js
+++ b/services/visual_recognition/v3.js
@@ -87,8 +87,7 @@ module.exports = function(RED) {
 
     var f = config['image-feature'];
 
-    if (msg.params && msg.params.detect_mode)
-    {
+    if (msg.params && msg.params.detect_mode) {
       if (msg.params.detect_mode in theOptions) {
         f = theOptions[msg.params.detect_mode];
       } else {


### PR DESCRIPTION
The detect_mode for Visual Recognition can now be set on msg.params.detect_mode. 
Allowed settings are : "classify", "faces" or "text"