### PR TITLE
Path fix for node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Node-RED Watson Nodes for IBM Bluemix
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.5.13
+- Personality Insights on Bluemix needed new path to node_modules
+
 ### New in version 0.5.12
 - Fix to Personality Insights Node when running in Japanese mode.
 - Bump Interface version to Discovery service to '2017-08-01'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "alchemy-api": "^1.3.0",

--- a/utilities/payload-utils.js
+++ b/utilities/payload-utils.js
@@ -120,7 +120,7 @@ PayloadUtils.prototype = {
         // default
         return cb(txt.split(' ').length);
       },
-      dic_path = '/../node_modules/kuromoji/dict',
+      dic_path = '/../../kuromoji/dict',
       dic_dir = path.normalize(__dirname + dic_path),
       tokenizer = null;
 


### PR DESCRIPTION
Recent change in node-red moves all node modules to a single folder. Hence the path to the kumoji dictionary needed to be modified.