### PR TITLE
Allow endpoint configuration for Discovery and NLU Nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Node-RED Watson Nodes for IBM Bluemix
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.5.14
+- Bump to latest version of watson-developer-cloud node.js sdk
+
 ### New in version 0.5.13
 - Personality Insights on Bluemix needed new path to node_modules
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Node-RED Watson Nodes for IBM Bluemix
 - Allow empty input into converse for Conversation Node
 - Endpoint can now be specified in Natural Language Understanding, Discovery and Discover Query Builder Nodes
 - Full Promises implementation for on input processing for Natural Language Understanding Node
+- Fix to node.error invocation in Conversation node.
 
 ### New in version 0.5.13
 - Personality Insights on Bluemix needed new path to node_modules

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Node-RED Watson Nodes for IBM Bluemix
 
 ### New in version 0.5.14
 - Bump to latest version of watson-developer-cloud node.js sdk
-- Allow empty input into Conversation converse
-- Endpoint can now be specified in Natural Language Understanding
+- Allow empty input into converse for Conversation Node
+- Endpoint can now be specified in Natural Language Understanding, Discovery and Discover Query Builder Nodes
+- Full Promises implementation for on input processing for Natural Language Understanding Node
 
 ### New in version 0.5.13
 - Personality Insights on Bluemix needed new path to node_modules

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Node-RED Watson Nodes for IBM Bluemix
 
 ### New in version 0.5.14
 - Bump to latest version of watson-developer-cloud node.js sdk
+- Allow empty input into Conversation converse
+- Endpoint can now be specified in Natural Language Understanding
 
 ### New in version 0.5.13
 - Personality Insights on Bluemix needed new path to node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "alchemy-api": "^1.3.0",
@@ -11,7 +11,7 @@
     "temp": "^0.8.3",
     "qs": "6.x",
 	  "image-type": "^2.0.2",
-    "watson-developer-cloud": "^2.37.0",
+    "watson-developer-cloud": "^2.39.2",
     "kuromoji": "^0.1.1",
     "is-docx": "^0.0.3",
     "stream-to-array" : "^2.3.0"

--- a/services/conversation/v1.html
+++ b/services/conversation/v1.html
@@ -59,6 +59,12 @@
         <input type="checkbox" id="node-input-multiuser" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-multiuser" style="width: 70%;"> Multiple Users</label>
     </div>
+    <div class="form-row">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-empty-payload" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-empty-payload" style="width: 70%;"> Permit empty payload</label>
+    </div>
+
     <div class="form-tips" id="conversation-form-tips">
       <strong>Note:</strong> When using with multiple users, <code>msg.user</code> must be set.<br>
       See info box for details.
@@ -140,6 +146,7 @@
               workspaceid: {value: ''},
               multiuser: {value: false},
               context: {value: true},
+              'empty-payload': {value: false},
               'default-endpoint' :{value: true},
               'service-endpoint' :{value: 'https://gateway.watsonplatform.net/conversation/api'}
             },

--- a/services/conversation/v1.js
+++ b/services/conversation/v1.js
@@ -188,7 +188,7 @@ module.exports = function(RED) {
 
   function processResponse(err, body, node, msg, config) {
     if (err !== null && body === null) {
-      node.error(err);
+      node.error(err, msg);
       node.status({
         fill: 'red',
         shape: 'ring',

--- a/services/conversation/v1.js
+++ b/services/conversation/v1.js
@@ -36,8 +36,8 @@ module.exports = function(RED) {
     } : null);
   });
 
-  function verifyPayload(node, msg) {
-    if (!msg.payload) {
+  function verifyPayload(node, msg, config) {
+    if (!(msg.payload || config['empty-payload'])) {
       node.status({
         fill: 'red',
         shape: 'ring',
@@ -237,7 +237,7 @@ module.exports = function(RED) {
 
       node.status({});
 
-      b = verifyPayload(node, msg);
+      b = verifyPayload(node, msg, config);
       if (!b) {
         return;
       }

--- a/services/discovery/v1-query-builder.html
+++ b/services/discovery/v1-query-builder.html
@@ -49,6 +49,16 @@
         <input type="password" id="node-input-password" placeholder="Password">
     </div>
 
+    <div class="form-row credentials">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-default-endpoint" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-default-endpoint" style="width: 70%;"> Use Default Service Endpoint</label>
+    </div>
+    <div class="form-row">
+        <label for="node-input-service-endpoint"><i class="fa fa-tag"></i> Service Endpoint</label>
+        <input type="text" id="node-input-service-endpoint" placeholder="https://gateway.watsonplatform.net/discovery/api">
+    </div>
+
     <div class="form-row">
         <label for="node-input-environment"><i class="fa fa-book"></i> Environment</label>
         <select type="text" id="node-input-environment" style="display: inline-block; vertical-align:middle; width: 70%;">
@@ -257,6 +267,15 @@
           }
       });
 
+      $('input#node-input-default-endpoint').change(function () {
+          var checked = $('input#node-input-default-endpoint').prop('checked')
+          if (checked) {
+              $('#node-input-service-endpoint').parent().hide();
+          } else {
+              $('#node-input-service-endpoint').parent().show();
+          }
+      });
+
     }
 
     // The dialog is about to be shown.
@@ -429,8 +448,13 @@
       var u = $('#node-input-username').val();
       var p = $('#node-input-password').val();
 
-      $.getJSON('watson-discovery-v1-query-builder/environments',
-                 {un: u, pwd: p}
+      var creds = {un: u, pwd: p};
+      var eChecked = $('input#node-input-default-endpoint').prop('checked')
+      if (!eChecked) {
+        creds.endpoint = $('#node-input-service-endpoint').val();
+      }
+
+      $.getJSON('watson-discovery-v1-query-builder/environments', creds
       ).done(function (data) {
         $('#something-went-wrong').hide();
         if (data.error) {
@@ -461,9 +485,14 @@
       var u = $('#node-input-username').val();
       var p = $('#node-input-password').val();
 
-      $.getJSON('watson-discovery-v1-query-builder/collections',
-                 {un: u, pwd: p,
-                  environment_id: disQB.environment_selected}
+      var creds = {un: u, pwd: p};
+      var eChecked = $('input#node-input-default-endpoint').prop('checked')
+      if (!eChecked) {
+        creds.endpoint = $('#node-input-service-endpoint').val();
+      }
+      creds.environment_id = disQB.environment_selected;
+
+      $.getJSON('watson-discovery-v1-query-builder/collections', creds
       ).done(function (data) {
         $('#something-went-wrong').hide();
         if (data.error) {
@@ -492,11 +521,15 @@
       var u = $('#node-input-username').val();
       var p = $('#node-input-password').val();
 
-      $.getJSON('watson-discovery-v1-query-builder/schemas',
-                 {un: u, pwd: p,
-                  environment_id: disQB.environment_selected,
-                  collection_id: disQB.collection_selected
-                 }
+      var creds = {un: u, pwd: p};
+      var eChecked = $('input#node-input-default-endpoint').prop('checked')
+      if (!eChecked) {
+        creds.endpoint = $('#node-input-service-endpoint').val();
+      }
+      creds.environment_id = disQB.environment_selected;
+      creds.collection_id = disQB.collection_selected;
+
+      $.getJSON('watson-discovery-v1-query-builder/schemas', creds
       ).done(function (data) {
         $('#something-went-wrong').hide();
         if (data.error) {
@@ -683,7 +716,10 @@
                 queryvalue3: {value: ''},
                 queryvalue3hidden: {value: ''},
                 passages: {value: false},
-                passageshidden: {value: false}
+                passageshidden: {value: false},
+                'default-endpoint' :{value: true},
+                'service-endpoint' :{value: 'https://gateway.watsonplatform.net/discovery/api'}
+
             },
             credentials: {
               username: {type:"text"} //,

--- a/services/discovery/v1-query-builder.js
+++ b/services/discovery/v1-query-builder.js
@@ -22,14 +22,15 @@ module.exports = function(RED) {
     DiscoveryV1 = require('watson-developer-cloud/discovery/v1'),
     serviceutils = require('../../utilities/service-utils'),
     dservice = serviceutils.getServiceCreds(SERVICE_IDENTIFIER),
-    username = null,
-    password = null,
     sUsername = null,
-    sPassword = null;
+    sPassword = null,
+    sEndpoint = 'https://gateway.watsonplatform.net/discovery/api';
+
 
   if (dservice) {
     sUsername = dservice.username;
     sPassword = dservice.password;
+    sEndpoint = dservice.url;
   }
 
   RED.httpAdmin.get('/watson-discovery-v1-query-builder/vcap', function(req, res) {
@@ -41,16 +42,20 @@ module.exports = function(RED) {
     var discovery = new DiscoveryV1({
       username: sUsername ? sUsername : req.query.un,
       password: sPassword ? sPassword : req.query.pwd,
+      url: req.query.endpoint ? req.query.endpoint : sEndpoint,
       version_date: '2017-08-01',
       headers: {
         'User-Agent': pkg.name + '-' + pkg.version
       }
     });
 
+    console.log('Getting Discovery Environments');
     discovery.getEnvironments({}, function(err, response) {
       if (err) {
+        console.log(err);
         res.json(err);
       } else {
+        console.log('Returning Envrionments');
         res.json(response.environments ? response.environments : response);
       }
     });
@@ -61,6 +66,7 @@ module.exports = function(RED) {
     var discovery = new DiscoveryV1({
       username: sUsername ? sUsername : req.query.un,
       password: sPassword ? sPassword : req.query.pwd,
+      url: req.query.endpoint ? req.query.endpoint : sEndpoint,
       version_date: '2017-08-01',
       headers: {
         'User-Agent': pkg.name + '-' + pkg.version
@@ -85,6 +91,7 @@ module.exports = function(RED) {
     var discovery = new DiscoveryV1({
       username: sUsername ? sUsername : req.query.un,
       password: sPassword ? sPassword : req.query.pwd,
+      url: req.query.endpoint ? req.query.endpoint : sEndpoint,      
       version_date: '2017-08-01',
       headers: {
         'User-Agent': pkg.name + '-' + pkg.version

--- a/services/discovery/v1.html
+++ b/services/discovery/v1.html
@@ -33,6 +33,16 @@
         <input type="password" id="node-input-password" placeholder="Password">
     </div>
 
+    <div class="form-row credentials">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-default-endpoint" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-default-endpoint" style="width: 70%;"> Use Default Service Endpoint</label>
+    </div>
+    <div class="form-row">
+        <label for="node-input-service-endpoint"><i class="fa fa-tag"></i> Service Endpoint</label>
+        <input type="text" id="node-input-service-endpoint" placeholder="https://gateway.watsonplatform.net/discovery/api">
+    </div>
+
     <div class="form-row">
         <label for="node-input-discovery-method"><i class="fa fa-book"></i> Method: </label>
         <select type="text" id="node-input-discovery-method" style="display: inline-block; width: 70%;">
@@ -357,6 +367,15 @@
         var method = $('#node-input-discovery-method').val();
         disV1.processSelectedMethod(method);
       });
+
+      $('input#node-input-default-endpoint').change(function () {
+          var checked = $('input#node-input-default-endpoint').prop('checked')
+          if (checked) {
+              $('#node-input-service-endpoint').parent().hide();
+          } else {
+              $('#node-input-service-endpoint').parent().show();
+          }
+      });
     }
 
     disV1.checkForPrepare = function () {
@@ -398,7 +417,9 @@
                 return: {value: ''},
                 description: {value: ''},
                 size: {value: 0},
-                'discovery-method': {value:'listEnvrionments'}
+                'discovery-method': {value:'listEnvrionments'},
+                'default-endpoint' :{value: true},
+                'service-endpoint' :{value: 'https://gateway.watsonplatform.net/discovery/api'}
             },
             credentials: {
               username: {type:'text'},

--- a/services/discovery/v1.js
+++ b/services/discovery/v1.js
@@ -232,9 +232,9 @@ module.exports = function (RED) {
       };
 
     if (endpoint) {
-        serviceSettings.url = endpoint;
+      serviceSettings.url = endpoint;
     }
-        
+
     discovery = new DiscoveryV1(serviceSettings);
 
     switch (method) {

--- a/services/language_translator_identify/v2.html
+++ b/services/language_translator_identify/v2.html
@@ -46,7 +46,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-language-translator-identify">
-    <p>Packaged in with release 0.5.11 of node-red-node-watson</p>
+    <p>Packaged in with release 0.5.14 of node-red-node-watson</p>
     <p>The Watson Language Translator service can be used to identify languages used in a text input. <p>
     <p>Node input : </p>
     <ul>

--- a/services/natural_language_understanding/v1.html
+++ b/services/natural_language_understanding/v1.html
@@ -30,6 +30,16 @@
         <input type="password" id="node-input-password" placeholder="Password">
     </div>
 
+    <div class="form-row credentials">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-default-endpoint" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-default-endpoint" style="width: 70%;"> Use Default Service Endpoint</label>
+    </div>
+    <div class="form-row">
+        <label for="node-input-service-endpoint"><i class="fa fa-tag"></i> Service Endpoint</label>
+        <input type="text" id="node-input-service-endpoint" placeholder="https://gateway.watsonplatform.net/natural-language-understanding/api">
+    </div>
+
     <div class="form-row">
         <label for="node-input-features" style="width: 100%"><i class="fa fa-book"></i> Extract the following features: </label>
           <div style="float: left;">
@@ -200,7 +210,7 @@
       To override the model used for entities set
       <code>msg.nlu_options.entity_model</code>.
       To override the model used for relations set
-      <code>msg.nlu_options.relations_model</code>. 
+      <code>msg.nlu_options.relations_model</code>.
     </p>
     <br>
     <p>Results from the API service will made available
@@ -271,6 +281,10 @@
                                     + ', #node-input-semantic-keywords'
                                     + ', #node-input-maxsemantics'));
 
+
+    nluV1.CreateIListener($('#node-input-default-endpoint'),
+                                $('#nnode-input-service-endpoint'));
+
   }
 
   nluV1.checkForPrepare = function () {
@@ -318,7 +332,9 @@
               'semantic': {value: false},
               'semantic-entities': {value: false},
               'semantic-keywords': {value: false},
-              'maxsemantics' :{value: '50'}
+              'maxsemantics' :{value: '50'},
+              'default-endpoint' :{value: true},
+              'service-endpoint' :{value: 'https://gateway.watsonplatform.net/natural-language-understanding/api'}
             },
             credentials: {
               username: {type:"text"},

--- a/services/natural_language_understanding/v1.js
+++ b/services/natural_language_understanding/v1.js
@@ -253,7 +253,7 @@ module.exports = function (RED) {
         })
         .then(function(){
           node.status({fill:'blue', shape:'dot', text:'requesting'});
-          return invokeService(options)
+          return invokeService(options);
         })
         .then(function(data){
           msg.features = data;
@@ -263,7 +263,7 @@ module.exports = function (RED) {
         .catch(function(err){
           reportError(node,msg,err);
         });
-        
+
     });
   }
 


### PR DESCRIPTION
- Bump to latest version of watson-developer-cloud node.js sdk
- Allow empty input into converse for Conversation Node
- Endpoint can now be specified in Natural Language Understanding, Discovery and Discover Query Builder Nodes
- Full Promises implementation for on input processing for Natural Language Understanding Node