### PR TITLE
Bump node module "request" version and fixed IE syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "async": "^1.5.2",
     "cfenv": "~1.0.0",
     "file-type": "^2.7.0",
-    "request": "~2.53.0",
+    "request": "~2.83.0",
     "temp": "^0.8.3",
     "qs": "6.x",
 	  "image-type": "^2.0.2",

--- a/services/natural_language_understanding/v1.html
+++ b/services/natural_language_understanding/v1.html
@@ -249,7 +249,8 @@
     }
   };
 
-  nluV1.CreateIListener = function(listen, action, opp=false) {
+  nluV1.CreateIListener = function(listen, action, opp) {
+    opp = typeof opp === 'undefined' ? false : opp;
     listen.change(function(val){
       var isSet = listen.prop('checked');
       if (opp) {


### PR DESCRIPTION
1) Prior to version 2.74.0 the request npm module was using tough-cookie < 2.3.0 which has a high ReDOS vulnerability rating. They have updated to use the newest version of tough-cookie that does not have the vulnerability in >= 2.74.0 version of request, hence I bumped request to version ~2.83.0. No breaking change was observed.

2) NLU v1.html is using ECMA5.1 syntax which breaks in IE11, so I updated the code to revert to ECMA3 syntax (minimal impact only).