### PR TITLE
Update links to developercloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Node-RED Watson Nodes for IBM Bluemix
+Node-RED Watson Nodes for IBM Cloud
 =====================================
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4f98536040924add9da4ca1deecb72b4)](https://www.codacy.com/app/BetaWorks-NodeRED-Watson/node-red-node-watson?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=watson-developer-cloud/node-red-node-watson&amp;utm_campaign=Badge_Grade)
@@ -138,7 +138,7 @@ Conversation workspace Manager node.
 
 
 ### Watson Nodes for Node-RED
-A collection of nodes to interact with the IBM Watson services in [IBM Bluemix](http://bluemix.net).
+A collection of nodes to interact with the IBM Watson services in [IBM Cloud](http://bluemix.net).
 
 # Nodes
 

--- a/services/conversation/v1-exp.html
+++ b/services/conversation/v1-exp.html
@@ -63,11 +63,11 @@
     <li><code>msg.result.input.entities</code>: the input used for the analysis Format: String </li>
     </ul>
 
-    <p><b>Important</b> : before using this node, a workspace must be created and configured using the Watson Conversation Tool available in Bluemix, in the Watson Conversation instance detail page.</p>
+    <p><b>Important</b> : before using this node, a workspace must be created and configured using the Watson Conversation Tool available in IBM Cloud, in the Watson Conversation instance detail page.</p>
     <br/>
 
-    <p>For full details, please see the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/conversation/overview.shtml">Watson Conversation API documentation</a></p>
-    <p>See also the <a href="https://watson-api-explorer.mybluemix.net/">API Explorer</a> and the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/conversation/tutorial_basic.shtml">Tutorial</a>.</p>
+    <p>For full details, please see the <a href="https://console.bluemix.net/docs/services/conversation/getting-started.html">Watson Conversation API documentation</a></p>
+    <p>See also the <a href="https://watson-api-explorer.mybluemix.net/apis/conversation-v1">API Explorer</a> and the <a href="https://console.bluemix.net/docs/services/conversation/tutorial.html">Tutorial: Building a complex dialog</a>.</p>
 
     <p>Check the sample Flow for this node on  <a href="https://github.com/watson-developer-cloud/node-red-bluemix-starter">Watson Node-RED Starter</a></p>
 </script>

--- a/services/conversation/v1-workspace-manager.html
+++ b/services/conversation/v1-workspace-manager.html
@@ -415,7 +415,7 @@
     </p>
 
     <p>For more information about the conversation service,
-    read the <a href="https://www.ibm.com/watson/developercloud/doc/conversation/index.html">
+    read the <a href="https://console.bluemix.net/docs/services/conversation/index.html">
     documentation</a>.</p>
 </script>
 

--- a/services/conversation/v1-workspace-manager.js
+++ b/services/conversation/v1-workspace-manager.js
@@ -1047,7 +1047,7 @@ module.exports = function (RED) {
   }
 
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/conversation/v1.html
+++ b/services/conversation/v1.html
@@ -95,12 +95,12 @@
     <p>See <a href="http://www.ibm.com/watson/developercloud/conversation/api/v1/#send_input" target="_blank">Conversation API documentation</a> for details.</p>
     <p>All Results will made available at <code>msg.payload</code> in JSON format. Check the  <a href="http://www.ibm.com/watson/developercloud/conversation/api/v1/#send_input" target="_blank">documentation</a> for details.</p>
 
-    <p><b>Important</b> : before using this node, a workspace must be created and configured using the Watson Conversation Tool available in Bluemix, in the Watson Conversation instance detail page.</p>
+    <p><b>Important</b> : before using this node, a workspace must be created and configured using the Watson Conversation Tool available in IBM Cloud, in the Watson Conversation instance detail page.</p>
     <p><b>Documentation</b>
     <ul>
-    <li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/" target="_blank">Watson Conversation API documentation</a></li>
-    <li><a href="https://watson-api-explorer.mybluemix.net/" target="_blank">Watson API Explorer</a></li>
-    <li><a href="http://www.ibm.com/watson/developercloud/doc/conversation/tutorial_basic.shtml" target="_blank">Basic tutorial</a>
+    <li><a href="https://console.bluemix.net/docs/services/conversation/index.html" target="_blank">Watson Conversation API documentation</a></li>
+    <li><a href="https://watson-api-explorer.mybluemix.net/apis/conversation-v1" target="_blank">Watson API Explorer</a></li>
+    <li><a href="https://console.bluemix.net/docs/services/conversation/getting-started.html" target="_blank">Getting started tutorial</a>
     <li><a href="https://github.com/watson-developer-cloud/node-red-bluemix-starter" target="_blank">Sample Flow in the Watson Node-RED Starter</a>
     </ul>
 </script>

--- a/services/discovery/v1-document-loader.html
+++ b/services/discovery/v1-document-loader.html
@@ -74,7 +74,7 @@
     </p>
 
     <p>For more information about the Discovery service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/discovery/">documentation</a>.</p>
+    read the service <a href="https://console.bluemix.net/docs/services/discovery/index.html">documentation</a>.</p>
 
 </script>
 

--- a/services/discovery/v1-exp.html
+++ b/services/discovery/v1-exp.html
@@ -123,7 +123,7 @@
         <br/>
     </ul>
     <p>For more information about the Discovery service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/discovery/">documentation</a>.</p>
+    read the service <a href="https://console.bluemix.net/docs/services/discovery/index.html">documentation</a>.</p>
 
 </script>
 

--- a/services/discovery/v1-query-builder.html
+++ b/services/discovery/v1-query-builder.html
@@ -151,7 +151,7 @@
     </p>
 
     <p>For more information about the Discovery service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/discovery/">documentation</a>.</p>
+    read the service <a href="https://console.bluemix.net/docs/services/discovery/index.html">documentation</a>.</p>
 
 </script>
 

--- a/services/discovery/v1.html
+++ b/services/discovery/v1.html
@@ -314,7 +314,7 @@
     </ul>
 
     <p>For more information about the Discovery service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/discovery/">documentation</a>.</p>
+    read the service <a href="https://console.bluemix.net/docs/services/discovery/index.html">documentation</a>.</p>
 
 </script>
 

--- a/services/document_conversion/v1.html
+++ b/services/document_conversion/v1.html
@@ -146,7 +146,7 @@
 	the configuration dialog for the node, it will be taken from <b>msg.target</b>. Optionally, details on how to format 
 	the file contents may be placed on <b>msg.word</b>, <b>msg.normalized_html</b> or <b>msg.txt</b> for Word, HTML or 
 	Text files (more information on the formatting can be found in the 
-	<a href='http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/document-conversion/customizing.shtml'> 
+	<a href='https://console.bluemix.net/docs/services/document-conversion/customizing.html'> 
 	Document Conversion API documentation</a>).
 </script>
 	

--- a/services/language_identification/v1.html
+++ b/services/language_identification/v1.html
@@ -43,7 +43,7 @@
     <p>The text to detect should be passed in on <code>msg.payload</code>.</p>
     <p>The ISO language code will be returned on <code>msg.lang</code>.</p>
     <p>For more information about the Language Identification service,
-    read the <a href="https://www.ibm.com/watson/developercloud/language-translation.html">documentation</a>.</p>
+    read the <a href="https://www.ibm.com/watson/services/language-translator/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translation/v2.html
+++ b/services/language_translation/v2.html
@@ -176,7 +176,7 @@
     <p><b>Local</b>  -  Local parametres if the node is used by its own (default value).</p>
     <p><b>Global</b> -  Global parametres if the node is used with the 'language translation util' and 'dropdonw' node.
     Global parameters are set when <b>local in unchecked</b>.</p>
-    <p>For more information about the Language Translation service, read the <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-translation.html">documentation</a>.</p>
+    <p>For more information about the Language Translation service, read the <a href="https://www.ibm.com/watson/services/language-translator/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translation/v2.js
+++ b/services/language_translation/v2.js
@@ -41,7 +41,7 @@ module.exports = function (RED) {
     sPassword = service.password;
   }
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/language_translation_util/v2.html
+++ b/services/language_translation_util/v2.html
@@ -53,7 +53,7 @@
     <p>Message Domains (e.g.: Conversational)<code>msg.domain</code>.</p>
     <p>Message Source Language (e.g.: English)<code>msg.source</code>.</p>
     <p>Message Targate Language (e.g.: French)<code>msg.target</code>.</p>
-    <p>For more information about the Language Translation service, read the <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/language-translation.html">documentation</a>.</p>
+    <p>For more information about the Language Translation service, read the <a href="https://www.ibm.com/watson/services/language-translator/">documentation</a>.</p>
 </script>
 
 

--- a/services/language_translation_util/v2.js
+++ b/services/language_translation_util/v2.js
@@ -38,7 +38,7 @@ module.exports = function (RED) {
     sPassword = service.password;
   }
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/language_translator/v2.html
+++ b/services/language_translator/v2.html
@@ -194,7 +194,7 @@
     <p><b>Local</b>  -  Local parametres if the node is used by its own (default value).</p>
     <p><b>Global</b> -  Global parametres if the node is used with the 'language translator util' and 'dropdown' node.
     Global parameters are set when <b>local in unchecked</b>.</p>
-    <p>For more information about the Language Translator service, read the <a href="https://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
+    <p>For more information about the Language Translator service, read the <a href="https://console.bluemix.net/docs/services/language-translator/index.html">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translator/v2.js
+++ b/services/language_translator/v2.js
@@ -48,7 +48,7 @@ module.exports = function (RED) {
     sEndpoint = service.url;
   }
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/language_translator_identify/v2.html
+++ b/services/language_translator_identify/v2.html
@@ -59,7 +59,7 @@
     with the associated confidence score</li>
     </ul>
     <p>For more information about the Language Identification service,
-    read the service <a href="https://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
+    read the service <a href="https://console.bluemix.net/docs/services/language-translator/index.html">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/language_translator_util/v2.html
+++ b/services/language_translator_util/v2.html
@@ -60,7 +60,7 @@
     <p>Message Domains (e.g.: Conversational)<code>msg.domain</code>.</p>
     <p>Message Source Language (e.g.: English)<code>msg.source</code>.</p>
     <p>Message Target Language (e.g.: French)<code>msg.target</code>.</p>
-    <p>For more information about the Language Translator service, read the <a href="http://www.ibm.com/watson/developercloud/doc/language-translator/index.html">documentation</a>.</p>
+    <p>For more information about the Language Translator service, read the <a href="https://console.bluemix.net/docs/services/language-translator/index.html">documentation</a>.</p>
 </script>
 
 

--- a/services/language_translator_util/v2.js
+++ b/services/language_translator_util/v2.js
@@ -31,7 +31,7 @@ module.exports = function (RED) {
     sEndpoint = service.url;
   }
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/natural_language_classifier/v1.html
+++ b/services/natural_language_classifier/v1.html
@@ -73,7 +73,7 @@
     <p></p>
     <p><b>Training Mode</b>.</p>
     <p>Set the training data language in the node configuration window.</p>
-    <p>The CSV training data should be passed in on <code>msg.payload</code> as a String or String Array. For more details on the training data format, see this <a href="http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html">link</a></p>
+    <p>The CSV training data should be passed in on <code>msg.payload</code> as a String or String Array. For more details on the training data format, see this <a href="https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html">link</a></p>
     <p>The returned classification training status will be returned on <code>msg.payload</code>.</p>
 	<p><b>List Mode</b>.</p>
     <p>Set the mode in the node configuration window.</p>

--- a/services/natural_language_understanding/v1.html
+++ b/services/natural_language_understanding/v1.html
@@ -198,7 +198,7 @@
     </ul>
     <p>For full details on the feature details,
       please see the
-      <a href="https://www.ibm.com/watson/developercloud/natural-language-understanding.html">
+      <a href="https://www.ibm.com/watson/services/natural-language-understanding/">
         service API documentation</a></p>
     <p>The content to be analysed should be passed in on <code>msg.payload</code>.</p>
     <p>Valid <code>msg.payload</code> types: URL, HTML or Text Content.</p>

--- a/services/personality_insights/v1.html
+++ b/services/personality_insights/v1.html
@@ -56,7 +56,7 @@
     <p>The text (minimum of a hundred words) to analyse should be passed in on <code>msg.payload</code>.</p>
     <p>You can set the source text language to be either English or Spanish.</p>
     <p>The insights will be returned as a tree on <code>msg.insights</code>.</p>
-    <p>For more information about the Personality Insights service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/personality-insights.html">documentation</a>.</p>
+    <p>For more information about the Personality Insights service, read the <a href="https://www.ibm.com/watson/services/personality-insights/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/personality_insights/v3.html
+++ b/services/personality_insights/v3.html
@@ -104,7 +104,7 @@
     </p>
     <p>The insights will be returned as a tree on <code>msg.insights</code>.</p>
     <p>For more information about the Personality Insights service,
-      read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/personality-insights.html">
+      read the <a href="https://www.ibm.com/watson/services/personality-insights/">
       documentation</a>.
     </p>
 </script>

--- a/services/retrieve_and_rank/v1.html
+++ b/services/retrieve_and_rank/v1.html
@@ -78,9 +78,9 @@
 
 <script type="text/x-red" data-help-name="watson-retrieve-rank-create-cluster">
 <p>The IBM Watson™ Retrieve and Rank service combines two information retrieval components in a single service: the power of Apache Solr and a sophisticated machine learning capability. This combination provides users with more relevant results by automatically reranking them by using these machine learning algorithms.</p>
-    <p>The create cluster node provisions a Solr cluster. You can specify the <b>size</b> of the cluster in the node configuration panel. For a small free cluster for testing choose the “Free” option. For more information about cluster sizing, see <a href="http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/retrieve-rank/solr_ops.shtml#sizing">Sizing your Retrieve and Rank cluster</a>. A <b>cluster name</b> can be specified in the node configuration panel or passed in on <code>msg.payload</code>. The cluster name specified in the node configuration panel takes priority.</p>
+    <p>The create cluster node provisions a Solr cluster. You can specify the <b>size</b> of the cluster in the node configuration panel. For a small free cluster for testing choose the “Free” option. For more information about cluster sizing, see <a href="https://console.bluemix.net/docs/services/retrieve-and-rank/using-solr.html#sizingCluster">Sizing your Retrieve and Rank cluster</a>. A <b>cluster name</b> can be specified in the node configuration panel or passed in on <code>msg.payload</code>. The cluster name specified in the node configuration panel takes priority.</p>
     <p>The cluster will then be created. This takes a short while to complete. When the cluster is available, the status underneath the node will change to <b>“Cluster available”</b>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -155,7 +155,7 @@
         <li><b>Delete Cluster </b>Delete a cluster from the service. The <code>cluster_id</code> can be passed into the node on <code>msg.cluster_id</code> or specified in the node configuration panel. The cluster id specified in the node configuration panel takes priority.</li>
     </ul>
     <p>The response from each query is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -235,7 +235,7 @@
     The <code>cluster_id</code> can be passed into the node on <code>msg.cluster_id</code> or specified in the node configuration panel. The cluster id specified in the node configuration panel takes priority.</li>
     The <code>configuration_name</code> can be passed into the node on <code>msg.configuration_name</code> or specified in the node configuration panel. The configuration_name specified in the node configuration panel takes priority.</li>
     <p>The response from the service is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -316,7 +316,7 @@
     The <code>configuration_name</code> can be passed into the node on <code>msg.configuration_name</code> or specified in the node configuration panel. The configuration_name specified in the node configuration panel takes priority.</li>
     </ul>
     <p>The response from each query is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -413,7 +413,7 @@
         <li><b>Search </b>Searches the collection based on a given query specified in <b>Solr standard query syntax</b>. This should be passed in as a <b>String</b> on <code>msg.payload</code>. The <code>cluster_id</code> and <code>collection_name</code> can be passed into the node on <code>msg.cluster_id</code> and <code>msg.collection_name</code> respectively, or specified in the node configuration panel. Parameters specified in the node configuration panel take priority.</li>
     </ul>
     <p>The response from each query is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -490,7 +490,7 @@
     <p>Once triggered, the ranker will then begin training. Once the ranker is available, the status underneath the node will change to <b>“Ranker Available”</b>.</p>
 
     <p>The ranker id is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -566,7 +566,7 @@
     </ul>
 
     <p>The result is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -652,7 +652,7 @@
     <p>The search and rank node returns reranked results for your query, where the query matches the <a href="https://cwiki.apache.org/confluence/display/solr/The+Standard+Query+Parser">Solr Standard Query Parser</a>. The <code>cluster_id</code>, <code>collection_name</code> and <code>ranker_id</code> can be passed into the node on <code>msg.cluster_id</code>, <code>msg.collection_name</code> and <code>msg.ranker_id</code> respectively, or specified in the node configuration panel. Parameters specified in the node configuration panel take priority.</p>
     <p>The search query is passed in on  <code>msg.payload</code> starting with <code>q=</code> to match the Solr Standard Query Parser.</p>
     <p>The result is returned on <code>msg.payload</code>.</p>
-    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/retrieve-rank.html">documentation</a>.</p>
+    <p>For more information about the Retrieve and Rank service, read the <a href="https://www.ibm.com/watson/services/retrieve-and-rank/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/speech_to_text/v1-corpus-builder.html
+++ b/services/speech_to_text/v1-corpus-builder.html
@@ -173,7 +173,7 @@
     </ul>
 
     <p>For more information about Speech To Text customisation,
-    read the <a href="https://www.ibm.com/watson/developercloud/doc/speech-to-text/custom.shtml#custom">
+    read the <a href="https://console.bluemix.net/docs/services/speech-to-text/custom.html">
     documentation</a>.</p>
 </script>
 

--- a/services/speech_to_text/v1-corpus-builder.js
+++ b/services/speech_to_text/v1-corpus-builder.js
@@ -350,7 +350,7 @@ module.exports = function (RED) {
   }
 
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/speech_to_text/v1.html
+++ b/services/speech_to_text/v1.html
@@ -128,7 +128,7 @@
     <p>The returned audio transcription will be returned on <code>msg.transcription</code>.</p>
     <p>The full response, including alternative transcriptions can be found on
     <code>msg.fullresult</code>.</p>
-    <p>For more information about the Speech To Text service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/speech-to-text.html">documentation</a>.</p>
+    <p>For more information about the Speech To Text service, read the <a href="https://www.ibm.com/watson/services/speech-to-text/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/speech_to_text/v1.js
+++ b/services/speech_to_text/v1.js
@@ -50,7 +50,7 @@ module.exports = function (RED) {
   // temp is being used for file streaming to allow the file to arrive so it can be processed.
   temp.track();
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/text_to_speech/v1-corpus-builder.html
+++ b/services/text_to_speech/v1-corpus-builder.html
@@ -121,7 +121,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="watson-text-to-speech-v1-query-builder">
-    <p>The Speech To Text Custom Builder is used to create customisations
+    <p>The Speech To Text Custom Builder is used to create customizations
     for Speech to Text. It supports the following modes </p>
     <ul>
 
@@ -176,8 +176,8 @@
 
     </ul>
 
-    <p>For more information about Speech To Text customisation,
-    read the <a href="https://www.ibm.com/watson/developercloud/doc/text-to-speech/custom-using.shtml#customUsing">
+    <p>For more information about Speech To Text customization,
+    read the <a href="https://console.bluemix.net/docs/services/text-to-speech/custom-using.html">
     documentation</a>.</p>
 </script>
 

--- a/services/text_to_speech/v1-corpus-builder.js
+++ b/services/text_to_speech/v1-corpus-builder.js
@@ -309,7 +309,7 @@ module.exports = function (RED) {
     return params;
   }
 
-  // These are APIs that the node has created to allow it to dynamically fetch Bluemix
+  // These are APIs that the node has created to allow it to dynamically fetch IBM Cloud
   // credentials, and also translation models. This allows the node to keep up to
   // date with new tranlations, without the need for a code update of this node.
 

--- a/services/text_to_speech/v1.html
+++ b/services/text_to_speech/v1.html
@@ -104,7 +104,7 @@
     <p><b>The source text must be in the language which matches the chosen voice, i.e. you cannot choose to a Spanish
     voice with English text.</b>.</p>
     <p>The returned audio transcription will be returned as a raw buffer containing the audio on <code>msg.speech</code>.</p>
-    <p>For more information about the Text To Speech service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/text-to-speech.html">documentation</a>.</p>
+    <p>For more information about the Text To Speech service, read the <a href="https://www.ibm.com/watson/services/text-to-speech/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/tone_analyzer/v3-beta.html
+++ b/services/tone_analyzer/v3-beta.html
@@ -58,7 +58,7 @@
     <p>The text to analyze should be passed in on <b>msg.payload</b>.</p>
     <p>The service response will be returned on <b>msg.response</b>.</p>
     <p>Usng the node editor dialog users can filter the results by tone (emotion, writing or social) and whether to include sentence-level analysis.</p>
-    <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>
+    <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/watson/services/tone-analyzer/">documentation</a>.</p>
     <p><b>NB:</b> This is the old beta version and it is only being retained for backward compatibility for anyone that has old credentials. It will no longer work with new credentials.</p>
 </script>
 

--- a/services/tone_analyzer/v3.html
+++ b/services/tone_analyzer/v3.html
@@ -104,7 +104,7 @@
       whether to include sentence-level analysis.</p>
     <p>When running the Conversational Chat Tone, the input needs to follow the
     chat json format for utterences. </p>
-    <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tone-analyzer.html">documentation</a>.</p>
+    <p>For more information about the Tone Analyzer service, read the <a href="https://www.ibm.com/watson/services/tone-analyzer/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/tradeoff_analytics/v1.html
+++ b/services/tradeoff_analytics/v1.html
@@ -48,7 +48,7 @@
     <p>The criteria columns should be passed in on <code>msg.columns</code>.</p>
     <p>The decision options should be passed in on <code>msg.options</code>.</p>
     <p>The resolution results will be returned on <code>msg.resolution</code>.</p>
-    <p>For more information about the Tradeoff Analytics service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/tradeoff-analytics.html">documentation</a>.</p>
+    <p>For more information about the Tradeoff Analytics service, read the <a href="https://www.ibm.com/watson/services/tone-analyzer/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">

--- a/services/visual_recognition/v1.html
+++ b/services/visual_recognition/v1.html
@@ -47,7 +47,7 @@
         <li><b>Buffer</b> Raw Image Bytes</li>
     </ul>
     <p>The identified images labels will be returned on <code>msg.labels</code>.</p>
-    <p>For more information about the Visual Recognition service, read the <a href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/visual-recognition.html">documentation</a>.</p>
+    <p>For more information about the Visual Recognition service, read the <a href="https://www.ibm.com/watson/services/visual-recognition/">documentation</a>.</p>
 </script>
 
 <script type="text/javascript">
@@ -364,7 +364,7 @@
     <br/>
     <p>A node for managing the classifiers in the Visual Recognition service in Watson</p>
 	<p>More information about this service can be found in the 
-	<a href='https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/visual-recognition/'>Image Recognition API documentation</a></p>.
+	<a href='https://console.bluemix.net/docs/services/visual-recognition/index.html'>Image Recognition API documentation</a></p>.
 </script>
 
 <script type="text/x-red" data-template-name="watson-visual-training">
@@ -405,7 +405,7 @@
 	zipped and provided to the node either as binary streams or as URL's. The positive and negative set of images 
 	should be pointed by <b>msg.positive</b> and <b>msg.negative</b>.</p>
 	<p>More information about this service can be found in the 
-	<a href='https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/visual-recognition/'>Image Recognition API documentation</a></p>.
+	<a href='https://console.bluemix.net/docs/services/visual-recognition/index.html'>Image Recognition API documentation</a></p>.
 </script>
 
 


### PR DESCRIPTION
Updating links that point to WDC documentation to go to the Watson
console.

- Update links that go to WDC to point to IBM Cloud (except for links
for deprecated services that weren't moved).
- Update references of Bluemix to IBM Cloud
- Update service landing pages from WDC to newer marketing pages
- Update links to demos that have moved from mybluemix.net to
bluemix.net