### PR TITLE
Natural Language Understanding Version Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Node-RED Watson Nodes for IBM Cloud
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.6.7
+- Enable Opt-out option for Conversation Node.
+- Implement time out option for response from Conversation Node.
+- Bump to v 3.2.1 of watson-developer-cloud dependency.
+
 
 ### New in version 0.6.6
 - Added Mute option for STT Node warning status when running in Streaming mode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Node-RED Watson Nodes for IBM Cloud
 - Enable Opt-out option for Conversation Node.
 - Implement time out option for response from Conversation Node.
 - Bump to v 3.2.1 of watson-developer-cloud dependency.
-
+- Fix to how API version is specified in Natural Language Understanding node. 
 
 ### New in version 0.6.6
 - Added Mute option for STT Node warning status when running in Streaming mode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Node-RED Watson Nodes for IBM Cloud
 - Enable Opt-out option for Conversation Node.
 - Implement time out option for response from Conversation Node.
 - Bump to v 3.2.1 of watson-developer-cloud dependency.
-- Fix to how API version is specified in Natural Language Understanding node. 
+- Fix to how API version is specified in Natural Language Understanding Node.
+- Add Korean to list of languages in Natural Language Classifier Node.
 
 ### New in version 0.6.6
 - Added Mute option for STT Node warning status when running in Streaming mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "async": "^1.5.2",
@@ -10,7 +10,7 @@
     "temp": "^0.8.3",
     "qs": "6.x",
 	  "image-type": "^2.0.2",
-    "watson-developer-cloud": "^3.0.6",
+    "watson-developer-cloud": "^3.2.1",
     "kuromoji": "^0.1.1",
     "word-count": "^0.2.2",
     "is-docx": "^0.0.3",

--- a/services/natural_language_classifier/v1.html
+++ b/services/natural_language_classifier/v1.html
@@ -65,6 +65,7 @@
             <option value="fr">French</option>
             <option value="it">Italian</option>
             <option value="ja">Japanese</option>
+            <option value="ko">Korean</option>
             <option value="pt">Portuguese</option>
             <option value="es">Spanish</option>
         </select>

--- a/services/natural_language_understanding/v1.js
+++ b/services/natural_language_understanding/v1.js
@@ -183,7 +183,7 @@ module.exports = function (RED) {
       serviceSettings = {
         username: username,
         password: password,
-        version_date: NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27,
+        version: '2018-03-16',
         headers: {
           'User-Agent': pkg.name + '-' + pkg.version
         }


### PR DESCRIPTION
Bump to v 3.2.1 of watson-developer-cloud dependency.
Fix to how API version is specified in Natural Language Understanding Node.
Add Korean to list of languages in Natural Language Classifier Node.