### PR TITLE
remove default name value for the NLU node

### DIFF
--- a/services/natural_language_understanding/v1.html
+++ b/services/natural_language_understanding/v1.html
@@ -315,7 +315,7 @@
         RED.nodes.registerType('natural-language-understanding', {
             category: 'IBM Watson',
             defaults: {
-              'name': {value: false},
+              'name': {value: ''},
               'categories': {value: false},
               'concepts': {value: false},
               'maxconcepts': {value: '8'},


### PR DESCRIPTION
Fixes the renaming of the node to false when no name is set.