### PR TITLE
Fix Collection Check in NLC Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Node-RED Watson Nodes for IBM Cloud
 
 <a href="https://cla-assistant.io/watson-developer-cloud/node-red-node-watson"><img src="https://cla-assistant.io/readme/badge/watson-developer-cloud/node-red-node-watson" alt="CLA assistant" /></a>
 
+### New in version 0.6.12
+- Fix to collection check in Natural Language Classification Node allowing for . in domain
+names.
+
 ### New in version 0.6.11
 - Fix to defaulting name for NLU Node.
 - Allow pre-check of audio format to be disabled in Speech to Text node.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-node-watson",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "A collection of Node-RED nodes for IBM Watson services",
   "dependencies": {
     "async": "^1.5.2",
     "cfenv": "~1.0.0",
     "file-type": "^2.7.0",
-    "request": "~2.83.0",
+    "request": "~2.86.0",
     "temp": "^0.8.3",
     "qs": "6.x",
 	  "image-type": "^2.0.2",

--- a/services/natural_language_classifier/v1.js
+++ b/services/natural_language_classifier/v1.js
@@ -83,7 +83,7 @@ module.exports = function(RED) {
     node.payloadCollectionCheck = function(msg, config, payloadData) {
       if ('classify' === config.mode) {
         if ('string' === typeof msg.payload) {
-          let collection = msg.payload.match( /\(?[^\.\?\!]+[\.!\?$]\)?/g );
+          let collection = msg.payload.match( /\(?([^.?!]|\.\w)+[.?!]\)?/g );
           if (collection && collection.length > 1) {
             payloadData.collection = [];
             collection.forEach((s) => {


### PR DESCRIPTION
Fix the regular expression that splits by sentences for a collection check. Domain names may contain . but not indicate the end of a sentence.