### PR TITLE
Rename Watson Assistant node in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A collection of nodes to interact with the IBM Watson services in [IBM Cloud](ht
 
 # Nodes
 
-- Conversation
+- Assistant (formerly Conversation)
     - Add conversational capabilities into applications.
 - Discovery
     - List environments created for the Discovery service


### PR DESCRIPTION
The node has been called Assistant on the palette for a while now.
This pull request just renames Conversation to Assistant in the README.md
No code changes, just a documentation change.