### PR TITLE
Added ability to disable ssl verification for Assistant node.

### DIFF
--- a/services/conversation/v1.html
+++ b/services/conversation/v1.html
@@ -108,6 +108,7 @@
     <li><code>msg.params.endpoint</code> : If provided will be used as the url for the Assistant service.</li>
     <li><code>msg.params.version</code> : If provided will be used as the API version date for the Assistant service.</li>
     <li><code>msg.params.optout_learning</code> : Set to true to opt out of request logging. Check the <a href="https://console.bluemix.net/docs/services/watson/getting-started-logging.html#controlling-request-logging-for-watson-services" target="_blank">documentation</a> for details.</li>
+    <li><code>msg.params.disable_ssl_verification</code> : Set to true to disable SSL verification. <b>Note that this has serious security implications - only do this if you really mean to!</b></li>
     </ul>
     <p>See <a href="http://www.ibm.com/watson/developercloud/assistant/api/v1/#send_input" target="_blank">Assistant API documentation</a> for details.</p>
     <p>All Results will made available at <code>msg.payload</code> in JSON format. Check the  <a href="http://www.ibm.com/watson/developercloud/assistant/api/v1/#send_input" target="_blank">documentation</a> for details.</p>

--- a/services/conversation/v1.js
+++ b/services/conversation/v1.js
@@ -229,6 +229,10 @@ module.exports = function(RED) {
       serviceSettings.timeout = parseInt(msg.params.timeout);
     }
 
+    if (msg.params && msg.params.disable_ssl_verification){
+      serviceSettings.disable_ssl_verification = true;
+    }
+
     node.service = new AssistantV1(serviceSettings);
     return true;
   }


### PR DESCRIPTION
Deliberately didn't add this option to dashboard as to avoid accidental security issue. 

Also, by supporting `msg.params` only, it means technical people (e.g. developer) is involved whom should know the consequence of this option.