### PR TITLE
Fix alternate intents configuration in params

### DIFF
--- a/services/assistant/v1.js
+++ b/services/assistant/v1.js
@@ -128,7 +128,7 @@ module.exports = function(RED) {
   function setAlternativeIntentsParams(node, msg, config, params) {
     // optional alternate_intents : boolean
     if (msg.params && msg.params.alternate_intents) {
-      params.alternate_intents = msg.params.alternate_intents;
+      params.alternateIntents = msg.params.alternate_intents;
     }
   }
 


### PR DESCRIPTION
The correct param name in `ibm-watson` is `alternateIntents` instead of `alternate_intents`. v2 is not impacted.

Reference:
https://github.com/watson-developer-cloud/node-sdk/blob/297c7de8034bdf3241b73764f0ce3d11088504bc/assistant/v1.ts#L92