### PR TITLE
allow customerId to be passed inside msg.params

### DIFF
--- a/services/assistant/v1.js
+++ b/services/assistant/v1.js
@@ -205,6 +205,9 @@ module.exports = function(RED) {
         if (msg.params.version) {
           version = msg.params.version;
         }
+        if (msg.params.customerId) {
+          serviceSettings.headers['X-Watson-Metadata'] = msg.params.customerId;
+        }
       }
 
       if (apiKey) {

--- a/services/assistant/v2.js
+++ b/services/assistant/v2.js
@@ -260,6 +260,9 @@ module.exports = function(RED) {
         if (msg.params.disable_ssl_verification){
           serviceSettings.disable_ssl_verification = true;
         }
+        if (msg.params.customerId) {
+          serviceSettings.headers['X-Watson-Metadata'] = msg.params.customerId;
+        }
       }
 
       serviceSettings.version = version;


### PR DESCRIPTION
Easy way to pass customerId inside msg.params.
It will be converted to **X-Watson-Metadata** header with **msg.params.customerId** value