### PR TITLE
Bump ibm-watson dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "request": "~2.88.2",
     "temp": "^0.9.4",
     "qs": "^6.10.3",
-    "ibm-watson": "^6.2.2",
+    "ibm-watson": "^9.1.0",
     "is-docx": "^0.0.3",
     "stream-to-array": "^2.3.0",
     "ws": "^8.5.0"


### PR DESCRIPTION
Bump ibm-watson dependency (and its version of axios 1.x) so that node-red-node-watson works on newer versions of Node.js

I ran into a similar "MODULE_NOT_FOUND" as described here
  https://discourse.nodered.org/t/need-help-with-why-i-cant-install-a-node-node-red-node-watson/82916/3
when I tried to run some of my older Node-RED flows on Node-RED 4.0.5

The Node-RED log reports errors for each of the node-red-node-watson nodes:
```
[warn] [node-red-node-watson/watson-speech-to-text-v1] Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/defaults' is not defined by "exports" in /opt/app-root/data/node_modules/axios/package.json
```

Even though node-red-node-watson 0.10.3 does not directly have a dependency on axios, the underlying ibm-watson package does.  From the node-red-node-watson `package.json`
```
    "ibm-watson": "^6.2.2",
```
That ibm-watson version pulls in the older axios "0.26.0" which seems to no longer work with newer versions of Node.js

Fixed by forking https://github.com/watson-developer-cloud/node-red-node-watson
to https://github.com/johnwalicki/node-red-node-watson/
I added one commit (this PR) to bump the ibm-watson dependency
`Bump ibm-watson to ^9.1.0`
which pulls in axios 1.7.* and now all of the node-red-node-watson nodes work on Node.js 20

How did I test it:
Node-RED 4.0.5 running in a container, 
with my flow with a package.json which points temporarily at my branch
```
        "node-red-node-watson": "github:johnwalicki/node-red-node-watson.git#bump-ibm-watson"
```        
I tested this patched node-red-node-watson with the newer `ibm-watson 9.1.0` **successfully** on Node.js v16, v18, v20        
I did not bump any other dependencies.